### PR TITLE
Protect important macro arguments with parentheses

### DIFF
--- a/src/uthash.h
+++ b/src/uthash.h
@@ -174,8 +174,8 @@ do {                                                                            
 do {                                                                             \
  unsigned _ha_bkt;                                                               \
  (add)->hh.next = NULL;                                                          \
- (add)->hh.key = (char*)keyptr;                                                  \
- (add)->hh.keylen = (unsigned)keylen_in;                                                   \
+ (add)->hh.key = (char*)(keyptr);                                                \
+ (add)->hh.keylen = (unsigned)(keylen_in);                                       \
  if (!(head)) {                                                                  \
     head = (add);                                                                \
     (head)->hh.prev = NULL;                                                      \
@@ -419,7 +419,7 @@ do {                                                                            
   unsigned char *_hj_key=(unsigned char*)(key);                                  \
   hashv = 0xfeedbeef;                                                            \
   _hj_i = _hj_j = 0x9e3779b9;                                                    \
-  _hj_k = (unsigned)keylen;                                                      \
+  _hj_k = (unsigned)(keylen);                                                      \
   while (_hj_k >= 12) {                                                          \
     _hj_i +=    (_hj_key[0] + ( (unsigned)_hj_key[1] << 8 )                      \
         + ( (unsigned)_hj_key[2] << 16 )                                         \


### PR DESCRIPTION
Background:
Without properly protecting those macro arguments a call like

```
 HASH_ADD_KEYPTR(hh, table, int_ptr + offset,
   size_t_end - size_t_begin, e);
```

yields a different hash computation than

```
 HASH_ADD_KEYPTR(hh, table, (int_ptr + offset),
   (size_t_end - size_t_begin), e);
```
