### PR TITLE
Update Bernstein hash function

### DIFF
--- a/src/uthash.h
+++ b/src/uthash.h
@@ -357,7 +357,7 @@ do {                                                                            
   unsigned _hb_keylen=keylen;                                                    \
   char *_hb_key=(char*)(key);                                                    \
   (hashv) = 0;                                                                   \
-  while (_hb_keylen--)  { (hashv) = ((hashv) * 33) + *_hb_key++; }               \
+  while (_hb_keylen--)  { (hashv) = ((hashv) << 5 + (hashv)) + *_hb_key++; }               \
   bkt = (hashv) & (num_bkts-1);                                                  \
 } while (0)
 


### PR DESCRIPTION
'hashv << 5 + hashv' will be faster than 'hashv \* 33'
