### PR TITLE
Fix 64-bit compatibility compiler warnings

### DIFF
--- a/src/uthash.h
+++ b/src/uthash.h
@@ -250,11 +250,11 @@ do {                                                                            
 
 /* convenience forms of HASH_FIND/HASH_ADD/HASH_DEL */
 #define HASH_FIND_STR(head,findstr,out)                                          \
-    HASH_FIND(hh,head,findstr,strlen(findstr),out)
+    HASH_FIND(hh,head,findstr,(unsigned)strlen(findstr),out)
 #define HASH_ADD_STR(head,strfield,add)                                          \
     HASH_ADD(hh,head,strfield[0],strlen(add->strfield),add)
 #define HASH_REPLACE_STR(head,strfield,add,replaced)                             \
-    HASH_REPLACE(hh,head,strfield[0],strlen(add->strfield),add,replaced)
+    HASH_REPLACE(hh,head,strfield[0],(unsigned)strlen(add->strfield),add,replaced)
 #define HASH_FIND_INT(head,findint,out)                                          \
     HASH_FIND(hh,head,findint,sizeof(int),out)
 #define HASH_ADD_INT(head,intfield,add)                                          \


### PR DESCRIPTION
Fix compiler warnings in case of sizeof(unsigned)!=sizeof(size_t)
- HASH_FIND_STR is tested
- HASH_REPLACE_STR is not tested
- no (additional) cast required for HASH_ADD_STR since already done in HASH_ADD_KEYPTR
