### PR TITLE
Fix -Wextra Warnings

### DIFF
--- a/opt/bundle/src/Makefile
+++ b/opt/bundle/src/Makefile
@@ -2,7 +2,7 @@ OBJS=libut.a
 all: $(OBJS) 
 INCDIR=../include
 CFLAGS=-I$(INCDIR)
-CFLAGS+=-Wall
+CFLAGS+=-Wall -Wextra
 CFLAGS+=-g
 
 libut.a: libut.o utvector.o 

--- a/opt/bundle/tests/Makefile
+++ b/opt/bundle/tests/Makefile
@@ -2,10 +2,10 @@ PROGS=test1 test2 test3 test4 test5 test6 test7 test8 test9 test10 test11 test12
       test13 test14 test15
 OBJS=$(patsubst %,%.o,$(PROGS))
 
-CFLAGS = -I../include -L../src
+CFLAGS = -I../include
 CFLAGS += -g
-CFLAGS += -Wall 
-LDFLAGS=-lut
+CFLAGS += -Wall -Wextra
+LDFLAGS=-lut -L../src
 
 TEST_TARGET=run_tests
 TESTS=./do_tests

--- a/src/utstring.h
+++ b/src/utstring.h
@@ -164,7 +164,7 @@ _UNUSED_ static void _utstring_BuildTable(
     i = 0;
     j = i - 1;
     P_KMP_Table[i] = j;
-    while (i < P_NeedleLen)
+    while (i < (long) P_NeedleLen)
     {
         while ( (j > -1) && (P_Needle[i] != P_Needle[j]) )
         {
@@ -172,7 +172,7 @@ _UNUSED_ static void _utstring_BuildTable(
         }
         i++;
         j++;
-        if (i < P_NeedleLen)
+        if (i < (long) P_NeedleLen)
         {
             if (P_Needle[i] == P_Needle[j])
             {
@@ -206,7 +206,7 @@ _UNUSED_ static void _utstring_BuildTableR(
     P_KMP_Table[i + 1] = j;
     while (i >= 0)
     {
-        while ( (j < P_NeedleLen) && (P_Needle[i] != P_Needle[j]) )
+        while ( (j < (long) P_NeedleLen) && (P_Needle[i] != P_Needle[j]) )
         {
            j = P_KMP_Table[j + 1];
         }
@@ -321,7 +321,7 @@ _UNUSED_ static long utstring_find(
         V_StartPosition = P_StartPosition;
     }
     V_HaystackLen = s->i - V_StartPosition;
-    if ( (V_HaystackLen >= P_NeedleLen) && (P_NeedleLen > 0) )
+    if ( (V_HaystackLen >= (long) P_NeedleLen) && (P_NeedleLen > 0) )
     {
         V_KMP_Table = (long *)malloc(sizeof(long) * (P_NeedleLen + 1));
         if (V_KMP_Table != NULL)
@@ -367,7 +367,7 @@ _UNUSED_ static long utstring_findR(
         V_StartPosition = P_StartPosition;
     }
     V_HaystackLen = V_StartPosition + 1;
-    if ( (V_HaystackLen >= P_NeedleLen) && (P_NeedleLen > 0) )
+    if ( (V_HaystackLen >= (long) P_NeedleLen) && (P_NeedleLen > 0) )
     {
         V_KMP_Table = (long *)malloc(sizeof(long) * (P_NeedleLen + 1));
         if (V_KMP_Table != NULL)


### PR DESCRIPTION
Cast size_t to long in long-size_t comparisons

```
In file included from ../include/libut.h:7:
../include/utstring.h:167:14: warning: comparison of integers of different signs: 'long' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
    while (i < P_NeedleLen)
           ~ ^ ~~~~~~~~~~~
../include/utstring.h:175:15: warning: comparison of integers of different signs: 'long' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
        if (i < P_NeedleLen)
            ~ ^ ~~~~~~~~~~~
../include/utstring.h:209:20: warning: comparison of integers of different signs: 'long' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
        while ( (j < P_NeedleLen) && (P_Needle[i] != P_Needle[j]) )
                 ~ ^ ~~~~~~~~~~~
../include/utstring.h:324:25: warning: comparison of integers of different signs: 'long' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
    if ( (V_HaystackLen >= P_NeedleLen) && (P_NeedleLen > 0) )
          ~~~~~~~~~~~~~ ^  ~~~~~~~~~~~
../include/utstring.h:370:25: warning: comparison of integers of different signs: 'long' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
    if ( (V_HaystackLen >= P_NeedleLen) && (P_NeedleLen > 0) )
          ~~~~~~~~~~~~~ ^  ~~~~~~~~~~~
5 warnings generated.
```
