### PR TITLE
Allow Overriding Of Hash Comparison Function

### DIFF
--- a/src/uthash.h
+++ b/src/uthash.h
@@ -601,7 +601,9 @@ do {                                                                   \
 #endif  /* HASH_USING_NO_STRICT_ALIASING */
 
 /* key comparison function; return 0 if keys equal */
-#define HASH_KEYCMP(a,b,len) memcmp(a,b,len)
+#ifndef HASH_KEYCMP
+#define HASH_KEYCMP(a,b,len) memcmp(a,b,len) == 0
+#endif
 
 /* iterate over items in a known bucket to find desired item */
 #define HASH_FIND_IN_BKT(tbl,hh,head,keyptr,keylen_in,out)                       \
@@ -610,7 +612,7 @@ do {                                                                            
  else out=NULL;                                                                  \
  while (out) {                                                                   \
     if ((out)->hh.keylen == keylen_in) {                                           \
-        if ((HASH_KEYCMP((out)->hh.key,keyptr,keylen_in)) == 0) break;             \
+        if (HASH_KEYCMP((out)->hh.key,keyptr,keylen_in)) break;                  \
     }                                                                            \
     if ((out)->hh.hh_next) DECLTYPE_ASSIGN(out,ELMT_FROM_HH(tbl,(out)->hh.hh_next)); \
     else out = NULL;                                                             \


### PR DESCRIPTION
My hash keys are uint64_ts, but LLVM 3.4 doesn't convert the `memcmp(a, b, sizeof(uint64_t))` to `*a == *b`. I'd therefore like to add the option of overriding the hash key comparison macro.
