### PR TITLE
Fix realloc and oom

### DIFF
--- a/src/utarray.h
+++ b/src/utarray.h
@@ -38,7 +38,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string.h>  /* memset, etc */
 #include <stdlib.h>  /* exit */
 
+#ifndef oom
 #define oom() exit(-1)
+#endif
 
 typedef void (ctor_f)(void *dst, const void *src);
 typedef void (dtor_f)(void *elt);

--- a/src/utarray.h
+++ b/src/utarray.h
@@ -88,11 +88,11 @@ typedef struct {
 
 #define utarray_reserve(a,by) do {                                            \
   if (((a)->i+(by)) > ((a)->n)) {                                             \
-    char *tmp;                                                                \
+    char *utarray_tmp;                                                        \
     while(((a)->i+(by)) > ((a)->n)) { (a)->n = ((a)->n ? (2*(a)->n) : 8); }   \
-    tmp=(char*)realloc((a)->d, (a)->n*(a)->icd.sz);                           \
-    if (tmp == NULL) oom();                                                   \
-    (a)->d=tmp;                                                               \
+    utarray_tmp=(char*)realloc((a)->d, (a)->n*(a)->icd.sz);                   \
+    if (utarray_tmp == NULL) oom();                                           \
+    (a)->d=utarray_tmp;                                                       \
   }                                                                           \
 } while(0)
 

--- a/src/utarray.h
+++ b/src/utarray.h
@@ -92,7 +92,7 @@ typedef struct {
     while(((a)->i+(by)) > ((a)->n)) { (a)->n = ((a)->n ? (2*(a)->n) : 8); }   \
     tmp=(char*)realloc((a)->d, (a)->n*(a)->icd.sz);                           \
     if (tmp == NULL) oom();                                                   \
-    (a)->d=tmp                                                                \
+    (a)->d=tmp;                                                               \
   }                                                                           \
 } while(0)
 

--- a/src/utarray.h
+++ b/src/utarray.h
@@ -86,8 +86,11 @@ typedef struct {
 
 #define utarray_reserve(a,by) do {                                            \
   if (((a)->i+(by)) > ((a)->n)) {                                             \
+    char *tmp;                                                                \
     while(((a)->i+(by)) > ((a)->n)) { (a)->n = ((a)->n ? (2*(a)->n) : 8); }   \
-    if ( ((a)->d=(char*)realloc((a)->d, (a)->n*(a)->icd.sz)) == NULL) oom();  \
+    tmp=(char*)realloc((a)->d, (a)->n*(a)->icd.sz);                           \
+    if (tmp == NULL) oom();                                                   \
+    (a)->d=tmp                                                                \
   }                                                                           \
 } while(0)
 

--- a/src/utstring.h
+++ b/src/utstring.h
@@ -38,7 +38,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string.h>
 #include <stdio.h>
 #include <stdarg.h>
+
+#ifndef oom
 #define oom() exit(-1)
+#endif
 
 typedef struct {
     char *d;

--- a/src/utstring.h
+++ b/src/utstring.h
@@ -49,9 +49,10 @@ typedef struct {
 #define utstring_reserve(s,amt)                            \
 do {                                                       \
   if (((s)->n - (s)->i) < (size_t)(amt)) {                 \
-     (s)->d = (char*)realloc((s)->d, (s)->n + (amt));      \
-     if ((s)->d == NULL) oom();                            \
-     (s)->n += (amt);                                      \
+    char *tmp = (char*)realloc((s)->d, (s)->n + (amt));    \
+    if (tmp == NULL) oom();                                \
+    (s)->d = tmp;                                          \
+    (s)->n += (amt);                                       \
   }                                                        \
 } while(0)
 

--- a/src/utstring.h
+++ b/src/utstring.h
@@ -52,9 +52,10 @@ typedef struct {
 #define utstring_reserve(s,amt)                            \
 do {                                                       \
   if (((s)->n - (s)->i) < (size_t)(amt)) {                 \
-    char *tmp = (char*)realloc((s)->d, (s)->n + (amt));    \
-    if (tmp == NULL) oom();                                \
-    (s)->d = tmp;                                          \
+    char *utstring_tmp = (char*)realloc(                   \
+      (s)->d, (s)->n + (amt));                             \
+    if (utstring_tmp == NULL) oom();                       \
+    (s)->d = utstring_tmp;                                 \
     (s)->n += (amt);                                       \
   }                                                        \
 } while(0)


### PR DESCRIPTION
With these changes it is now possible to have `#define oom() break` and do not have memory leaks in case `realloc` fails.