### PR TITLE
Patch Makefiles to honor CPPFLAGS

### DIFF
--- a/libut/Makefile
+++ b/libut/Makefile
@@ -18,7 +18,7 @@ utmm.o: src/utmm.c $(INCDIR)/utmm.h
 	$(CC) $(CFLAGS) $(CPPFLAGS) -c $<
 
 ringbuf.o: src/ringbuf.c $(INCDIR)/ringbuf.h
-	$(CC) $(CFLAGS) -c $<
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c $<
 
 .PHONY: clean tests install
 


### PR DESCRIPTION
Add the missing CPPFLAGS to the 'ringbuf.o' target. This is needed in
order to pass extra flags when building uthash for Debian.