### PR TITLE
Add HASH_VALUE and HASH_FIND_BY_HASH_VALUE primitives; breaking change to HASH_FCN

### DIFF
--- a/doc/userguide.txt
+++ b/doc/userguide.txt
@@ -1712,18 +1712,23 @@ than `hh`, or if your key's data type isn't `int` or `char[]`.
 .General macros
 [width="90%",cols="10m,30m",grid="none",options="header"]
 |===============================================================================
-|macro          | arguments
-|HASH_ADD       | (hh_name, head, keyfield_name, key_len, item_ptr)
-|HASH_ADD_KEYPTR| (hh_name, head, key_ptr, key_len, item_ptr)
-|HASH_REPLACE   | (hh_name, head, keyfield_name, key_len, item_ptr, replaced_item_ptr)
-|HASH_FIND      | (hh_name, head, key_ptr, key_len, item_ptr)
-|HASH_DELETE    | (hh_name, head, item_ptr)
-|HASH_SRT       | (hh_name, head, cmp)
-|HASH_CNT       | (hh_name, head)
-|HASH_CLEAR     | (hh_name, head)
-|HASH_SELECT    | (dst_hh_name, dst_head, src_hh_name, src_head, condition)
-|HASH_ITER      | (hh_name, head, item_ptr, tmp_item_ptr)
-|HASH_OVERHEAD  | (hh_name, head)
+|macro                        | arguments
+|HASH_ADD                     | (hh_name, head, keyfield_name, key_len, item_ptr)
+|HASH_ADD_BY_HASH_VALUE       | (hh_name, head, keyfield_name, key_len, key_hash, item_ptr)
+|HASH_ADD_KEYPTR              | (hh_name, head, key_ptr, key_len, item_ptr)
+|HASH_ADD_KEYPTR_BY_HASH_VALUE| (hh_name, head, key_ptr, key_len, key_hash, item_ptr)
+|HASH_REPLACE                 | (hh_name, head, keyfield_name, key_len, item_ptr, replaced_item_ptr)
+|HASH_REPLACE_BY_HASH_VALUE   | (hh_name, head, keyfield_name, key_len, key_hash, item_ptr, replaced_item_ptr)
+|HASH_FIND                    | (hh_name, head, key_ptr, key_len, item_ptr)
+|HASH_FIND_BY_HASH_VALUE      | (hh_name, head, key_ptr, key_len, key_hash, item_ptr)
+|HASH_DELETE                  | (hh_name, head, item_ptr)
+|HASH_VALUE                   | (key_ptr, key_len, key_hash)
+|HASH_SRT                     | (hh_name, head, cmp)
+|HASH_CNT                     | (hh_name, head)
+|HASH_CLEAR                   | (hh_name, head)
+|HASH_SELECT                  | (dst_hh_name, dst_head, src_hh_name, src_head, condition)
+|HASH_ITER                    | (hh_name, head, item_ptr, tmp_item_ptr)
+|HASH_OVERHEAD                | (hh_name, head)
 |===============================================================================
 
 [NOTE]
@@ -1752,6 +1757,11 @@ key_ptr::
     for `HASH_FIND`, this is a pointer to the key to look up in the hash
     (since it's a pointer, you can't directly pass a literal value here). For
     `HASH_ADD_KEYPTR`, this is the address of the key of the item being added.
+key_hash::
+    the hash value of the provided key. This is an input parameter for the
+    `..._BY_HASH_VALUE` macros, and an output parameter for `HASH_VALUE`.
+    Reusing a cached hash value can be a performance optimization if
+    you're going to do repeated lookups for the same key.
 item_ptr::
     pointer to the structure being added, deleted, or looked up, or the current
     pointer during iteration. This is an input parameter for `HASH_ADD` and


### PR DESCRIPTION
This patch separates the "hash a key into an `unsigned` hashvalue" step (now known as `HASH_VALUE`) from the "modulo a hashvalue into a bucket" step (still known as `HASH_TO_BKT`). This lets us remove two arguments from each of the `HASH_JEN` etc. hash function macros, because they no longer need to care about the number of buckets in the table.

The performance improvement here is that client code can compute the `HASH_VALUE` for a given key just once, store it locally, and then use that hashvalue to search for the same key in many different hash tables — or to search for it once, and then quickly insert it when it's not found — or to search for it multiple times in the same hash table.

Notice that the third commit in this PR is an API-breaking change for clients who are currently passing `-DHASH_FUNCTION=some_custom_function`. It is *not* a breaking change for clients passing `-DHASH_FUNCTION=HASH_SAX` or whatever; and it's not a quietly breaking change for anyone AFAICT.