### PR TITLE
unsigned casting in utstring_len macro cause truncation on 64 bit (ch…

### DIFF
--- a/src/utstring.h
+++ b/src/utstring.h
@@ -117,7 +117,7 @@ do {                                                             \
   (dst)->d[(dst)->i]='\0';                                       \
 } while(0)
 
-#define utstring_len(s) ((unsigned)((s)->i))
+#define utstring_len(s) ((size_t)((s)->i))
 
 #define utstring_body(s) ((s)->d)
 

--- a/src/utstring.h
+++ b/src/utstring.h
@@ -117,7 +117,7 @@ do {                                                             \
   (dst)->d[(dst)->i]='\0';                                       \
 } while(0)
 
-#define utstring_len(s) ((size_t)((s)->i))
+#define utstring_len(s) ((s)->i)
 
 #define utstring_body(s) ((s)->d)
 


### PR DESCRIPTION
…anged to size_t). Range of 'unsigned' is half of 'size_t'. sizeof(unsigned)4 vs. sizeof(size_t)8.