### PR TITLE
Fix #99: segfault in HASH_ADD_KEYPTR_INORDER.

### DIFF
--- a/src/uthash.h
+++ b/src/uthash.h
@@ -242,20 +242,20 @@ do {                                                                            
     (head) = (add);                                                              \
     HASH_MAKE_TABLE(hh, head);                                                   \
   } else {                                                                       \
-    struct UT_hash_handle *_hs_iter = &(head)->hh;                               \
+    void *_hs_iter = (head);                                                     \
     (add)->hh.tbl = (head)->hh.tbl;                                              \
     do {                                                                         \
-      if (cmpfcn(DECLTYPE(head) ELMT_FROM_HH((head)->hh.tbl, _hs_iter), add) > 0) \
+      if (cmpfcn(DECLTYPE(head)(_hs_iter), add) > 0)                             \
         break;                                                                   \
-    } while ((_hs_iter = _hs_iter->next));                                       \
+    } while ((_hs_iter = HH_FROM_ELMT((head)->hh.tbl, _hs_iter)->next));         \
     if (_hs_iter) {                                                              \
       (add)->hh.next = _hs_iter;                                                 \
-      if (((add)->hh.prev = _hs_iter->prev)) {                                   \
-        HH_FROM_ELMT((head)->hh.tbl, _hs_iter->prev)->next = (add);              \
+      if (((add)->hh.prev = HH_FROM_ELMT((head)->hh.tbl, _hs_iter)->prev)) {     \
+        HH_FROM_ELMT((head)->hh.tbl, (add)->hh.prev)->next = (add);              \
       } else {                                                                   \
         (head) = (add);                                                          \
       }                                                                          \
-      _hs_iter->prev = (add);                                                    \
+      HH_FROM_ELMT((head)->hh.tbl, _hs_iter)->prev = (add);                      \
     } else {                                                                     \
       HASH_APPEND_LIST(hh, head, add);                                           \
     }                                                                            \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,7 +13,8 @@ PROGS = test1 test2 test3 test4 test5 test6 test7 test8 test9   \
         test58 test59 test60 test61 test62 test63 test64 test65 \
         test66 test67 test68 test69 test70 test71 test72 test73 \
         test74 test75 test76 test77 test78 test79 test80 test81 \
-        test82 test83 test84 test85 test86 test87 test88 test89
+        test82 test83 test84 test85 test86 test87 test88 test89 \
+        test90
 CFLAGS += -I$(HASHDIR)
 #CFLAGS += -DHASH_BLOOM=16
 #CFLAGS += -O2

--- a/tests/test87.c
+++ b/tests/test87.c
@@ -3,9 +3,9 @@
 #include "uthash.h"
 
 typedef struct {
-    UT_hash_handle hh;
     char name[32];
     int weight;
+    UT_hash_handle hh;
 } hstruct_t;
 
 static int cmpfunc(const hstruct_t *s1, const hstruct_t *s2)
@@ -39,19 +39,19 @@ int main()
     unsigned hashvalue;
 
     hstruct_t tst[] = {
-        {{0}, "muh1", 2},
-        {{0}, "muh2", 8},
-        {{0}, "muh3", 1},
-        {{0}, "muh4", 8},
-        {{0}, "muh5", 3},
-        {{0}, "muh6", 5},
-        {{0}, "muh7", 6},
-        {{0}, "muh8", 15},
-        {{0}, "muh9", 6},
-        {{0}, "muh10", 9},
-        {{0}, "muh11", 10},
-        {{0}, "muh12", 43},
-        {{0}, "muh12", 7}
+        {"muh1", 2,   {0}},
+        {"muh2", 8,   {0}},
+        {"muh3", 1,   {0}},
+        {"muh4", 8,   {0}},
+        {"muh5", 3,   {0}},
+        {"muh6", 5,   {0}},
+        {"muh7", 6,   {0}},
+        {"muh8", 15,  {0}},
+        {"muh9", 6,   {0}},
+        {"muh10", 9,  {0}},
+        {"muh11", 10, {0}},
+        {"muh12", 43, {0}},
+        {"muh12", 7,  {0}}
     };
 
     int index;

--- a/tests/test90.ans
+++ b/tests/test90.ans
@@ -1,0 +1,2 @@
+filling in is ok
+cleanup is ok

--- a/tests/test90.c
+++ b/tests/test90.c
@@ -1,0 +1,52 @@
+#include <assert.h>
+#include <stdio.h>
+#include "uthash.h"
+
+struct item {
+    unsigned char *sort_field;
+    size_t sort_field_len; /** Sort field length, in bytes */
+    int some_user_data;
+    UT_hash_handle hh;
+};
+
+int sort_func(const struct item *a, const struct item *b)
+{
+    int va = *(int*)a->sort_field;
+    int vb = *(int*)b->sort_field;
+    return (va < vb) ? -1 : (va > vb);
+}
+
+int main()
+{
+    size_t i;
+    struct item *p, *tmp;
+    int total = 0;
+
+    /** The sorted list */
+    struct item *list = NULL;
+    int counter = 0;
+
+    /* fill in the sorted list */
+    for(i=0; i<100; i++) {
+        p = malloc(sizeof *p);
+
+        p->sort_field_len = sizeof(int);
+        p->sort_field = malloc(p->sort_field_len);
+        *(int*)p->sort_field = counter++;
+
+        HASH_ADD_KEYPTR_INORDER(hh, list, p->sort_field, p->sort_field_len, p, sort_func);
+    }
+
+    printf("filling in is ok\n");
+
+    HASH_ITER(hh, list, p, tmp) {
+        total += *(int*)p->sort_field;
+        HASH_DEL(list, p);
+        free(p->sort_field);
+        free(p);
+    }
+    assert(total == 4950);  // sum of 0 through 99
+
+    printf("cleanup is ok\n");
+    return 0;
+}


### PR DESCRIPTION
Thanks to @IronBug for the bug report (#99) and test90.c!

test87.c would have caught this bug at the time the macros were added,
except that by chance `offsetof(hstruct_t, hh)` was `0`. I've adjusted
the test so that it fails before this patch and succeeds after.