### PR TITLE
Add "Android" to the list of supported platforms

### DIFF
--- a/doc/userguide.txt
+++ b/doc/userguide.txt
@@ -55,6 +55,7 @@ This software can be used in C and C++ programs.  It has been tested on:
  * Solaris
  * OpenBSD
  * FreeBSD
+ * Android
 
 Test suite
 ^^^^^^^^^^


### PR DESCRIPTION
Requested by @silvioprog! He writes:

> It worked like a charm for my ARMv7 and finally I can use an efficient
> C hash table in my Android (tested on version 5 and 6) application.

Sure, technically "Android" is covered by "Linux" anyway. :)

Fixes #103.