### PR TITLE
Added macros HASH_TOP and HASH_NEXT for dataset-style iteration.

### DIFF
--- a/src/uthash.h
+++ b/src/uthash.h
@@ -999,6 +999,38 @@ for(((el)=(head)), ((tmp)=DECLTYPE(el)((head!=NULL)?(head)->hh.next:NULL));     
   (el) != NULL; ((el)=(tmp)), ((tmp)=DECLTYPE(el)((tmp!=NULL)?(tmp)->hh.next:NULL)))
 #endif
 
+#ifdef NO_DECLTYPE
+#define HASH_TOP(hh,head,el,tmp,eof)                                             \
+do {                                                                             \
+  ((el)=(head));                                                                 \
+  ((*(char**)(&(tmp)))=(char*)((head!=NULL)?(head)->hh.next:NULL));              \
+  ((*eof)=((el) == NULL));                                                       \
+} while(0)
+#else
+#define HASH_TOP(hh,head,el,tmp,eof)                                             \
+do {                                                                             \
+  ((el)=(head));                                                                 \
+  ((tmp)=DECLTYPE(el)((head!=NULL)?(head)->hh.next:NULL));                       \
+  ((*eof)=((el) == NULL));                                                       \
+} while(0)
+#endif
+
+#ifdef NO_DECLTYPE
+#define HASH_NEXT(hh,head,el,tmp,eof)                                            \
+do {                                                                             \
+  ((el)=(tmp));                                                                  \
+  ((*(char**)(&(tmp)))=(char*)((tmp!=NULL)?(tmp)->hh.next:NULL));                \
+  ((*eof)=((el) == NULL));                                                       \
+} while(0)
+#else
+#define HASH_NEXT(hh,head,el,tmp,eof)                                            \
+do {                                                                             \
+  ((el)=(tmp));                                                                  \
+  ((tmp)=DECLTYPE(el)((tmp!=NULL)?(tmp)->hh.next:NULL));                         \
+  ((*eof)=((el) == NULL));                                                       \
+} while(0)
+#endif
+
 /* obtain a count of items in the hash */
 #define HASH_COUNT(head) HASH_CNT(hh,head)
 #define HASH_CNT(hh,head) ((head != NULL)?((head)->hh.tbl->num_items):0U)


### PR DESCRIPTION
Hello masters,

This feature would be very, very useful for the ones who want to use uthash as library in other languages that offer `for in` support, like Pascal, JS, Java etc., because instead of exporting a callback-style iterator via `HASH_ITER`, these macros iterates in dataset-style (top/next) using a `boolean` type, signaling the end of hash table, like showed in the example below:

```c
#include "uthash.h"
#include <stdio.h>
#include <stdbool.h>

struct my_struct {
    int id;
    char name[20];
    UT_hash_handle hh;
};

struct my_struct *users = NULL;

void add_user(int user_id, char *name) {
    struct my_struct *s;
    s = malloc(sizeof(struct my_struct));
    s->id = user_id;
    strcpy(s->name, name);
    HASH_ADD_INT(users, id, s);
}

void delete_all() {
    struct my_struct *current_user, *tmp;

    HASH_ITER(hh, users, current_user, tmp) {
        HASH_DEL(users, current_user);
        free(current_user);
    }
}

int main() {
    struct my_struct *user, *tmp;
    bool users_eof;

    add_user(100, "Syd Barrett");
    add_user(101, "Roger Waters");
    add_user(102, "David Gilmour");
    add_user(103, "Richard Wright");
    add_user(104, "Nick Mason");

    HASH_TOP(hh, users, user, tmp, &users_eof);
    while (!users_eof) {
        printf("%d - %s\n", user->id, user->name);
        HASH_NEXT(hh, users, user, tmp, &users_eof);
    }

    delete_all();
    return 0;
}
```
```bash
$ ./a.out
100 - Syd Barrett
101 - Roger Waters
102 - David Gilmour
103 - Richard Wright
104 - Nick Mason
```
In general, the languages that offer the `for in` support implements their lists in dataset-style, and the programmer must implement two methods: `GetCurrent()`/`MoveToNext()`. Therefore, `HASH_TOP`/`HASH_NEXT` would be useful for them. :-)

What do you think about this feature? (if it was accepted I finally would be able to create a uthash binding for Pascal :-) )

Thank you!