### PR TITLE
Added macros HASH_TOP and HASH_NEXT for dataset-style iteration.

### DIFF
--- a/src/uthash.h
+++ b/src/uthash.h
@@ -999,6 +999,34 @@ for(((el)=(head)), ((tmp)=DECLTYPE(el)((head!=NULL)?(head)->hh.next:NULL));     
   (el) != NULL; ((el)=(tmp)), ((tmp)=DECLTYPE(el)((tmp!=NULL)?(tmp)->hh.next:NULL)))
 #endif
 
+#ifdef NO_DECLTYPE
+#define HASH_TOP(hh,head,el,tmp)                                                 \
+do {                                                                             \
+  (el) = (head);                                                                 \
+  *(char**)(&(tmp)) = (char*)((head!=NULL)?(head)->hh.next:NULL);                \
+} while (0)
+#else
+#define HASH_TOP(hh,head,el,tmp)                                                 \
+do {                                                                             \
+  (el) = (head);                                                                 \
+  (tmp) = DECLTYPE(el)((head!=NULL)?(head)->hh.next:NULL);                       \
+} while (0)
+#endif
+
+#ifdef NO_DECLTYPE
+#define HASH_NEXT(hh,head,el,tmp)                                                \
+do {                                                                             \
+  (el) = (tmp);                                                                  \
+  *(char**)(&(tmp)) = (char*)((tmp!=NULL)?(tmp)->hh.next:NULL);                  \
+} while (0)
+#else
+#define HASH_NEXT(hh,head,el,tmp)                                                \
+do {                                                                             \
+  (el) = (tmp);                                                                  \
+  (tmp) = DECLTYPE(el)((tmp!=NULL)?(tmp)->hh.next:NULL);                         \
+} while (0)
+#endif
+
 /* obtain a count of items in the hash */
 #define HASH_COUNT(head) HASH_CNT(hh,head)
 #define HASH_CNT(hh,head) ((head != NULL)?((head)->hh.tbl->num_items):0U)


### PR DESCRIPTION
Hello,

This PR 109 adds macros `HASH_TOP` and `HASH_NEXT` for dataset-style iteration. See the example below:

```c
#include "uthash.h"
#include <stdio.h>

struct my_struct {
    int id;
    char name[20];
    UT_hash_handle hh;
};

struct my_struct *users = NULL;

void add_user(int user_id, char *name) {
    struct my_struct *s;
    s = malloc(sizeof(struct my_struct));
    s->id = user_id;
    strcpy(s->name, name);
    HASH_ADD_INT(users, id, s);
}

void delete_all() {
    struct my_struct *current_user, *tmp;

    HASH_ITER(hh, users, current_user, tmp) {
        HASH_DEL(users, current_user);
        free(current_user);
    }
}

int main() {
    struct my_struct *user, *tmp;

    add_user(100, "Syd Barrett");
    add_user(101, "Roger Waters");
    add_user(102, "David Gilmour");
    add_user(103, "Richard Wright");
    add_user(104, "Nick Mason");

    HASH_TOP(hh, users, user, tmp);
    while (user) {
        printf("%d - %s\n", user->id, user->name);
        HASH_NEXT(hh, users, user, tmp);
    }

    delete_all();
    return 0;
}
```
```bash
./a.out
100 - Syd Barrett
101 - Roger Waters
102 - David Gilmour
103 - Richard Wright
104 - Nick Mason
```