### PR TITLE
Fix issues reported by PVS-Studio

### DIFF
--- a/src/uthash.h
+++ b/src/uthash.h
@@ -196,10 +196,10 @@ do {                                                                            
 #define HASH_BLOOM_BITTEST(bv,idx) (bv[(idx)/8U] & (1U << ((idx)%8U)))
 
 #define HASH_BLOOM_ADD(tbl,hashv)                                                \
-  HASH_BLOOM_BITSET((tbl)->bloom_bv, (hashv & (uint32_t)((1UL << (tbl)->bloom_nbits) - 1U)))
+  HASH_BLOOM_BITSET((tbl)->bloom_bv, ((hashv) & (uint32_t)((1UL << (tbl)->bloom_nbits) - 1U)))
 
 #define HASH_BLOOM_TEST(tbl,hashv)                                               \
-  HASH_BLOOM_BITTEST((tbl)->bloom_bv, (hashv & (uint32_t)((1UL << (tbl)->bloom_nbits) - 1U)))
+  HASH_BLOOM_BITTEST((tbl)->bloom_bv, ((hashv) & (uint32_t)((1UL << (tbl)->bloom_nbits) - 1U)))
 
 #else
 #define HASH_BLOOM_MAKE(tbl,oomed)


### PR DESCRIPTION
* V1003 The macro 'HASH_BLOOM_ADD' is a dangerous expression. The parameter 'hashv' must be surrounded by parentheses. uthash.h 199
* V1003 The macro 'HASH_BLOOM_TEST' is a dangerous expression. The parameter 'hashv' must be surrounded by parentheses. uthash.h 202