### PR TITLE
utstring.h: fix wrong sequence of parameters calling calloc().

### DIFF
--- a/src/utstring.h
+++ b/src/utstring.h
@@ -81,7 +81,7 @@ do {                                                       \
 
 #define utstring_new(s)                                    \
 do {                                                       \
-   s = (UT_string*)calloc(sizeof(UT_string),1);            \
+   s = (UT_string*)calloc(1,sizeof(UT_string));            \
    if (!s) oom();                                          \
    utstring_init(s);                                       \
 } while(0)


### PR DESCRIPTION
Hello.

According to `man 3 calloc`, the first parameter of `calloc()` function is the `nmemb` of elements:

```bash
SYNOPSIS

...

       void *calloc(size_t nmemb, size_t size);

...

DESCRIPTION

...

       The  calloc()  function allocates memory for an array of nmemb elements
       of size bytes each and returns a pointer to the allocated memory.   The
       memory  is  set  to zero.  If nmemb or size is 0, then calloc() returns
       either NULL, or a unique pointer value that can later  be  successfully
       passed to free().
```

So this PR should fix it.

(notice it was property used [here](https://github.com/troydhanson/uthash/blob/e7f4693a8dccaac0a7379b107df5197c1b232891/tests/test20.c#L18)).

Thank you!