### PR TITLE
Fix warnings issued by -Wpadded (gcc/clang).

### DIFF
--- a/src/uthash.h
+++ b/src/uthash.h
@@ -26,6 +26,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define UTHASH_VERSION 2.0.2
 
+#ifndef DUTHASH_V2_ABI
+#define DUTHASH_V2_ABI
+#endif
+
 #include <string.h>   /* memcmp, memset, strlen */
 #include <stddef.h>   /* ptrdiff_t */
 #include <stdlib.h>   /* exit */
@@ -1172,11 +1176,16 @@ typedef struct UT_hash_bucket {
 
 typedef struct UT_hash_table {
    UT_hash_bucket *buckets;
-   struct UT_hash_handle *tail; /* tail hh in app order, for fast append     */
-   ptrdiff_t hho; /* hash handle offset (byte pos of hash handle in element) */
-
+#ifdef DUTHASH_V2_ABI
+   struct UT_hash_handle *tail; /* tail hh in app order, for fast append    */
+   ptrdiff_t hho; /* hash handle offset (byte pos of hash handle in element */
+#endif
    unsigned num_buckets, log2_num_buckets;
    unsigned num_items;
+#ifndef DUTHASH_V2_ABI
+   struct UT_hash_handle *tail; /* tail hh in app order, for fast append    */
+   ptrdiff_t hho; /* hash handle offset (byte pos of hash handle in element */
+#endif
 
    /* in an ideal situation (all buckets used equally), no bucket would have
     * more than ceil(#items/#buckets) items. that's the ideal chain length. */

--- a/src/uthash.h
+++ b/src/uthash.h
@@ -1172,10 +1172,11 @@ typedef struct UT_hash_bucket {
 
 typedef struct UT_hash_table {
    UT_hash_bucket *buckets;
+   struct UT_hash_handle *tail; /* tail hh in app order, for fast append     */
+   ptrdiff_t hho; /* hash handle offset (byte pos of hash handle in element) */
+
    unsigned num_buckets, log2_num_buckets;
    unsigned num_items;
-   struct UT_hash_handle *tail; /* tail hh in app order, for fast append    */
-   ptrdiff_t hho; /* hash handle offset (byte pos of hash handle in element */
 
    /* in an ideal situation (all buckets used equally), no bucket would have
     * more than ceil(#items/#buckets) items. that's the ideal chain length. */


### PR DESCRIPTION
This PR fixes the following errors (passing `-Wall -Werror -Wextra -Wpedantic -Wpadded`):

```bash
src/uthash.h:1177:27: error: padding struct to align ‘tail’ [-Werror=padded]
    struct UT_hash_handle *tail; /* tail hh in app order, for fast append    */
                           ^
src/uthash.h:1204:1: error: padding struct size to alignment boundary [-Werror=padded]
 } UT_hash_table;
```