### PR TITLE
Trim trailing whitespaces

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,9 +1,9 @@
 HTML=$(patsubst %.txt,%.html,$(wildcard *.txt))
 
 all: $(HTML)
-  
-# when each target of a multi-target rule has its own prereq 
-# we use a static pattern rule. 
+
+# when each target of a multi-target rule has its own prereq
+# we use a static pattern rule.
 $(HTML): %.html: %.txt
 	asciidoc -a toc2 $<
 

--- a/doc/index.html
+++ b/doc/index.html
@@ -64,14 +64,14 @@ Example 1. Adding an item to a hash.
 
 struct my_struct {
     int id;            /* we'll use this field as the key */
-    char name[10];             
+    char name[10];
     UT_hash_handle hh; /* makes this structure hashable */
 };
 
 struct my_struct *users = NULL;
 
 void add_user(struct my_struct *s) {
-    HASH_ADD_INT( users, id, s );    
+    HASH_ADD_INT( users, id, s );
 }
 
 </pre>
@@ -85,7 +85,7 @@ Example 2. Looking up an item in a hash.
 struct my_struct *find_user(int user_id) {
     struct my_struct *s;
 
-    HASH_FIND_INT( users, &amp;user_id, s );  
+    HASH_FIND_INT( users, &amp;user_id, s );
     return s;
 }
 
@@ -99,7 +99,7 @@ Example 3. Deleting an item from a hash.
 
 <pre>
 void delete_user(struct my_struct *user) {
-    HASH_DEL( users, user);  
+    HASH_DEL( users, user);
 }
 
 </pre>

--- a/src/utringbuffer.h
+++ b/src/utringbuffer.h
@@ -27,11 +27,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define UTRINGBUFFER_H
 
 #define UTRINGBUFFER_VERSION 2.0.2
- 
+
 #include <stdlib.h>
 #include <string.h>
 #include "utarray.h"  // for "UT_icd"
- 
+
 typedef struct {
     unsigned i;       /* index of next available slot; wraps at n */
     unsigned n;       /* capacity */
@@ -39,14 +39,14 @@ typedef struct {
     UT_icd icd;       /* initializer, copy and destructor functions */
     char *d;          /* n slots of size icd->sz */
 } UT_ringbuffer;
- 
+
 #define utringbuffer_init(a, _n, _icd) do {                               \
   memset(a, 0, sizeof(UT_ringbuffer));                                    \
   (a)->icd = *(_icd);                                                     \
   (a)->n = (_n);                                                          \
   if ((a)->n) { (a)->d = (char*)malloc((a)->n * (_icd)->sz); }            \
 } while(0)
- 
+
 #define utringbuffer_clear(a) do {                                        \
   if ((a)->icd.dtor) {                                                    \
     if ((a)->f) {                                                         \
@@ -64,42 +64,42 @@ typedef struct {
   (a)->i = 0;                                                             \
   (a)->f = 0;                                                             \
 } while(0)
- 
+
 #define utringbuffer_done(a) do {                                         \
   utringbuffer_clear(a);                                                  \
   free((a)->d); (a)->d = NULL;                                            \
   (a)->n = 0;                                                             \
 } while(0)
- 
+
 #define utringbuffer_new(a,n,_icd) do {                                   \
   a = (UT_ringbuffer*)malloc(sizeof(UT_ringbuffer));                      \
   utringbuffer_init(a, n, _icd);                                          \
 } while(0)
- 
+
 #define utringbuffer_free(a) do {                                         \
   utringbuffer_done(a);                                                   \
   free(a);                                                                \
 } while(0)
- 
+
 #define utringbuffer_push_back(a,p) do {                                                \
   if ((a)->icd.dtor && (a)->f) { (a)->icd.dtor(_utringbuffer_internalptr(a,(a)->i)); }  \
   if ((a)->icd.copy) { (a)->icd.copy( _utringbuffer_internalptr(a,(a)->i), p); }        \
   else { memcpy(_utringbuffer_internalptr(a,(a)->i), p, (a)->icd.sz); };                \
   if (++(a)->i == (a)->n) { (a)->i = 0; (a)->f = 1; }                                   \
 } while(0)
- 
+
 #define utringbuffer_len(a) ((a)->f ? (a)->n : (a)->i)
 #define utringbuffer_empty(a) ((a)->i == 0 && !(a)->f)
 #define utringbuffer_full(a) ((a)->f != 0)
- 
+
 #define _utringbuffer_real_idx(a,j) ((a)->f ? ((j) + (a)->i) % (a)->n : (j))
 #define _utringbuffer_internalptr(a,j) ((void*)((a)->d + ((a)->icd.sz * (j))))
 #define utringbuffer_eltptr(a,j) ((0 <= (j) && (j) < utringbuffer_len(a)) ? _utringbuffer_internalptr(a,_utringbuffer_real_idx(a,j)) : NULL)
- 
+
 #define _utringbuffer_fake_idx(a,j) ((a)->f ? ((j) + (a)->n - (a)->i) % (a)->n : (j))
 #define _utringbuffer_internalidx(a,e) (((char*)(e) >= (a)->d) ? (((char*)(e) - (a)->d)/(a)->icd.sz) : -1)
 #define utringbuffer_eltidx(a,e) _utringbuffer_fake_idx(a, _utringbuffer_internalidx(a,e))
- 
+
 #define utringbuffer_front(a) utringbuffer_eltptr(a,0)
 #define utringbuffer_next(a,e) ((e)==NULL ? utringbuffer_front(a) : utringbuffer_eltptr(a, utringbuffer_eltidx(a,e)+1))
 #define utringbuffer_prev(a,e) ((e)==NULL ? utringbuffer_back(a) : utringbuffer_eltptr(a, utringbuffer_eltidx(a,e)-1))

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -18,8 +18,8 @@ CFLAGS += -I$(HASHDIR)
 #CFLAGS += -O2
 CFLAGS += -g
 #CFLAGS += -Wstrict-aliasing=2
-CFLAGS += -Wall 
-#CFLAGS += -Wextra 
+CFLAGS += -Wall
+#CFLAGS += -Wextra
 #CFLAGS += -std=c89
 CFLAGS += ${EXTRA_CFLAGS}
 
@@ -74,7 +74,7 @@ pedantic:
 	$(MAKE) all HASH_PEDANTIC=1
 
 cplusplus:
-	CC=$(CXX) $(MAKE) all 
+	CC=$(CXX) $(MAKE) all
 
 thorough:
 	$(MAKE) clean && $(MAKE) all EXTRA_CFLAGS='-pedantic'
@@ -97,7 +97,7 @@ hashscan : $(HASHDIR)/uthash.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(MUR_CFLAGS) $(LDFLAGS) -o $@ $(@).c
 	@$(MKGITIGN)
 
-sleep_test : $(HASHDIR)/uthash.h 
+sleep_test : $(HASHDIR)/uthash.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -DHASH_BLOOM=16 $(LDFLAGS) -o $@ $(@).c
 	@$(MKGITIGN)
 
@@ -121,6 +121,6 @@ astyle:
 
 .PHONY: clean astyle
 
-clean:	
+clean:
 	rm -f $(UTILS) $(PLAT_UTILS) $(PROGS) test*.out keystat.??? example hashscan sleep_test *.exe $(GITIGN)
 	rm -rf *.dSYM

--- a/tests/README
+++ b/tests/README
@@ -4,7 +4,7 @@ Run "make" in this directory to build the tests and run them.
 
 test1:  make 10-item hash, iterate and print each one
 test2:  make 10-item hash, lookup items with even keys, print
-test3:  make 10-item hash, delete items with even keys, print others 
+test3:  make 10-item hash, delete items with even keys, print others
 test4:  10 structs have dual hash handles, separate keys
 test5:  10 structs have dual hash handles, lookup evens by alt key
 test6:  test alt malloc macros (and alt memcmp macro)
@@ -29,7 +29,7 @@ test24: make 10-item hash and confirm item count (HASH_COUNT)
 test25: CDL / DL / LL tests
 test26: test the linked list sort macros in utlist.h
 test27: LL_APPEND, SORT
-test28: CDL / DL / LL tests  
+test28: CDL / DL / LL tests
 test29: DL_APPEND, SORT
 test30: CDL_PREPEND, SORT
 test31: CDL_PREPEND, SORT
@@ -60,7 +60,7 @@ test55: test utstring
 test56: test uthash, utlist and utstring together for #define conflicts etc
 test57: test uthash HASH_ADD_PTR and HASH_FIND_PTR
 test58: test HASH_ITER macro
-test59: sample of multi-level hash 
+test59: sample of multi-level hash
 test60: sample of multi-level hash that also does HASH_DEL and free
 test61: test utarray_find
 test62: test macros used in safe unaligned reads on non-Intel type platforms

--- a/tests/threads/Makefile
+++ b/tests/threads/Makefile
@@ -3,9 +3,9 @@ PROGS = test1 test2
 
 # Thread support requires compiler-specific options
 # ----------------------------------------------------------------------------
-# GNU 
+# GNU
 CFLAGS += -I$(HASHDIR) -g -pthread
-# Solaris (Studio 11) 
+# Solaris (Studio 11)
 #CFLAGS = -I$(HASHDIR) -g -mt
 # ----------------------------------------------------------------------------
 
@@ -26,6 +26,6 @@ run_tests: $(PROGS)
 
 .PHONY: clean
 
-clean:	
-	rm -f $(PROGS) test*.out 
+clean:
+	rm -f $(PROGS) test*.out
 	rm -rf test*.dSYM


### PR DESCRIPTION
Hello, this is a minor patch to clear trailing whitespaces in source code files for convenience. Some editors trim these automatically and to not have these changes as part of other commits.

Thank you.