### PR TITLE
Remove hashing in HASH_FIND when head is null

### DIFF
--- a/src/uthash.h
+++ b/src/uthash.h
@@ -176,8 +176,11 @@ do {                                                                            
 #define HASH_FIND(hh,head,keyptr,keylen,out)                                     \
 do {                                                                             \
   unsigned _hf_hashv;                                                            \
-  HASH_VALUE(keyptr, keylen, _hf_hashv);                                         \
-  HASH_FIND_BYHASHVALUE(hh, head, keyptr, keylen, _hf_hashv, out);               \
+  (out) = NULL;                                                                  \
+  if (head) {                                                                    \
+    HASH_VALUE(keyptr, keylen, _hf_hashv);                                       \
+    HASH_FIND_BYHASHVALUE(hh, head, keyptr, keylen, _hf_hashv, out);             \
+  }                                                                              \
 } while (0)
 
 #ifdef HASH_BLOOM


### PR DESCRIPTION
The hashing part in HASH_FIND is not needed when the table does not exist. This mainly helps reduce the costly calculation of HASH_VALUE for certain cases. We found and fixed this issue for [https://github.com/pmodels/mpich](https://github.com/pmodels/mpich).