### PR TITLE
Pacify a compiler with strict alignment warnings.

### DIFF
--- a/src/uthash.h
+++ b/src/uthash.h
@@ -144,7 +144,7 @@ typedef unsigned char uint8_t;
 /* calculate the element whose hash handle address is hhp */
 #define ELMT_FROM_HH(tbl,hhp) ((void*)(((char*)(hhp)) - ((tbl)->hho)))
 /* calculate the hash handle from element address elp */
-#define HH_FROM_ELMT(tbl,elp) ((UT_hash_handle *)(((char*)(elp)) + ((tbl)->hho)))
+#define HH_FROM_ELMT(tbl,elp) ((UT_hash_handle *)(void*)(((char*)(elp)) + ((tbl)->hho)))
 
 #define HASH_ROLLBACK_BKT(hh, head, itemptrhh)                                   \
 do {                                                                             \


### PR DESCRIPTION
Our compiler for CHERI (http://cheri-cpu.org) has extremely strict
alignment warnings and complains about HH_FROM_ELMT's cast from a char*
to UT_hash_handle*.  Cast through a (void*) to passify the warning.