### PR TITLE
Fix clang static analyzer false positive

### DIFF
--- a/src/uthash.h
+++ b/src/uthash.h
@@ -473,6 +473,7 @@ do {                                                                            
       (head)->hh.tbl->tail = HH_FROM_ELMT((head)->hh.tbl, _hd_hh_del->prev);     \
     }                                                                            \
     if (_hd_hh_del->prev != NULL) {                                              \
+      assert(&(head)->hh != _hd_hh_del);                                         \
       HH_FROM_ELMT((head)->hh.tbl, _hd_hh_del->prev)->next = _hd_hh_del->next;   \
     } else {                                                                     \
       DECLTYPE_ASSIGN(head, _hd_hh_del->next);                                   \


### PR DESCRIPTION
Fixes #128. Clang static analyzer was thinking that it's possible to
free() list head without updating head pointer. This assert assures
static analyzer that branch without head pointer update could be taken
only when we are freeing non-head element.