### PR TITLE
tests/do_tests.mingw: fix error that .exe's cannot be found

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -122,5 +122,5 @@ astyle:
 .PHONY: clean astyle
 
 clean:
-	rm -f $(UTILS) $(PLAT_UTILS) $(PROGS) test*.out keystat.??? example hashscan sleep_test *.exe $(GITIGN)
+	rm -f $(UTILS) $(PLAT_UTILS) $(PROGS) test*.out keystat.??? example hashscan sleep_test *.exe $(GITIGN) *.diff
 	rm -rf *.dSYM

--- a/tests/do_tests.mingw
+++ b/tests/do_tests.mingw
@@ -5,7 +5,7 @@ echo "MinGW test script starting"
 for f in test*.exe
 do
   t=`echo $f | sed s/.exe//`
-  `$f > $t.out`
+  "./$f" > "$t.out"
   diff -qb "$t.out" "$t.ans"
   if [ $? -eq 1 ]
   then

--- a/tests/do_tests.mingw
+++ b/tests/do_tests.mingw
@@ -6,14 +6,7 @@ for f in test*.exe
 do
   t=`echo $f | sed s/.exe//`
   "./$f" > "$t.out"
-  diff -qb "$t.out" "$t.ans"
-  if [ $? -eq 1 ]
-  then
-    echo "$f failed"
-  else
-    true # can't have empty else
-    #echo "$f passed"
-  fi
+  diff -b "$t.out" "$t.ans" > "$t.diff" && rm "$t.diff" || echo "$f failed"
 done
 
 echo 


### PR DESCRIPTION
Essentially replace `test.exe` by `./test.exe`, such that `bash` can find it. 