### PR TITLE
Honor user's CFLAGS

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,22 +13,22 @@ PROGS = test1 test2 test3 test4 test5 test6 test7 test8 test9   \
         test74 test75 test76 test77 test78 test79 test80 test81 \
         test82 test83 test84 test85 test86 test87 test88 test89 \
         test90 test91 test92 test93 test94 test95
-CFLAGS += -I$(HASHDIR)
-#CFLAGS += -DHASH_BLOOM=16
-#CFLAGS += -O2
-CFLAGS += -g
-#CFLAGS += -Wstrict-aliasing=2
-CFLAGS += -Wall
-#CFLAGS += -Wextra
-#CFLAGS += -std=c89
-CFLAGS += ${EXTRA_CFLAGS}
+UTH_CFLAGS += -I$(HASHDIR)
+#UTH_CFLAGS += -DHASH_BLOOM=16
+#UTH_CFLAGS += -O2
+UTH_CFLAGS += -g
+#UTH_CFLAGS += -Wstrict-aliasing=2
+UTH_CFLAGS += -Wall
+#UTH_CFLAGS += -Wextra
+#UTH_CFLAGS += -std=c89
+UTH_CFLAGS += ${EXTRA_CFLAGS}
 
 ifeq ($(HASH_DEBUG),1)
-CFLAGS += -DHASH_DEBUG=1
+UTH_CFLAGS += -DHASH_DEBUG=1
 endif
 
 ifeq ($(HASH_PEDANTIC),1)
-CFLAGS += -pedantic
+UTH_CFLAGS += -pedantic
 endif
 
 TEST_TARGET=run_tests
@@ -87,28 +87,28 @@ thorough:
 	$(MAKE) clean && CC=$(CXX) $(MAKE) tests_only EXTRA_CFLAGS='-pedantic -DHASH_USING_NO_STRICT_ALIASING -fno-strict-aliasing -DHASH_FUNCTION=HASH_MUR'
 
 example: example.c $(HASHDIR)/uthash.h
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $(@).c
+	$(CC) $(CPPFLAGS) $(UTH_CFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $(@).c
 
 $(PROGS) $(UTILS) : $(HASHDIR)/uthash.h
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $(@).c
+	$(CC) $(CPPFLAGS) $(UTH_CFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $(@).c
 	@$(MKGITIGN)
 
 hashscan : $(HASHDIR)/uthash.h
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(MUR_CFLAGS) $(LDFLAGS) -o $@ $(@).c
+	$(CC) $(CPPFLAGS) $(UTH_CFLAGS) $(MUR_CFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $(@).c
 	@$(MKGITIGN)
 
 sleep_test : $(HASHDIR)/uthash.h
-	$(CC) $(CPPFLAGS) $(CFLAGS) -DHASH_BLOOM=16 $(LDFLAGS) -o $@ $(@).c
+	$(CC) $(CPPFLAGS) $(UTH_CFLAGS) -DHASH_BLOOM=16 $(CFLAGS) $(LDFLAGS) -o $@ $(@).c
 	@$(MKGITIGN)
 
 keystat : $(HASHDIR)/uthash.h
-	$(CC) $(CPPFLAGS) $(CFLAGS) -DHASH_FUNCTION=HASH_BER $(LDFLAGS) -o keystat.BER keystat.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) -DHASH_FUNCTION=HASH_FNV $(LDFLAGS) -o keystat.FNV keystat.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) -DHASH_FUNCTION=HASH_JEN $(LDFLAGS) -o keystat.JEN keystat.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) -DHASH_FUNCTION=HASH_OAT $(LDFLAGS) -o keystat.OAT keystat.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) -DHASH_FUNCTION=HASH_SAX $(LDFLAGS) -o keystat.SAX keystat.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) -DHASH_FUNCTION=HASH_SFH $(LDFLAGS) -o keystat.SFH keystat.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(MUR_CFLAGS) -DHASH_FUNCTION=HASH_MUR $(LDFLAGS) -o keystat.MUR keystat.c
+	$(CC) $(CPPFLAGS) $(UTH_CFLAGS) -DHASH_FUNCTION=HASH_BER $(CFLAGS) $(LDFLAGS) -o keystat.BER keystat.c
+	$(CC) $(CPPFLAGS) $(UTH_CFLAGS) -DHASH_FUNCTION=HASH_FNV $(CFLAGS) $(LDFLAGS) -o keystat.FNV keystat.c
+	$(CC) $(CPPFLAGS) $(UTH_CFLAGS) -DHASH_FUNCTION=HASH_JEN $(CFLAGS) $(LDFLAGS) -o keystat.JEN keystat.c
+	$(CC) $(CPPFLAGS) $(UTH_CFLAGS) -DHASH_FUNCTION=HASH_OAT $(CFLAGS) $(LDFLAGS) -o keystat.OAT keystat.c
+	$(CC) $(CPPFLAGS) $(UTH_CFLAGS) -DHASH_FUNCTION=HASH_SAX $(CFLAGS) $(LDFLAGS) -o keystat.SAX keystat.c
+	$(CC) $(CPPFLAGS) $(UTH_CFLAGS) -DHASH_FUNCTION=HASH_SFH $(CFLAGS) $(LDFLAGS) -o keystat.SFH keystat.c
+	$(CC) $(CPPFLAGS) $(UTH_CFLAGS) $(MUR_CFLAGS) -DHASH_FUNCTION=HASH_MUR $(CFLAGS) $(LDFLAGS) -o keystat.MUR keystat.c
 
 run_tests: $(PROGS)
 	perl $(TESTS)


### PR DESCRIPTION
The project's required `CFLAGS` are gathered in `UTH_CFLAGS` and used in the target recipes. It leaves `CFLAGS` for the user. Also see https://www.gnu.org/prep/standards/html_node/Command-Variables.html.