### PR TITLE
uthash.h: fix compiler warning -Wswitch-default

### DIFF
--- a/src/uthash.h
+++ b/src/uthash.h
@@ -695,7 +695,8 @@ do {                                                                            
     case 4:  _hj_i += ( (unsigned)_hj_key[3] << 24 );  /* FALLTHROUGH */         \
     case 3:  _hj_i += ( (unsigned)_hj_key[2] << 16 );  /* FALLTHROUGH */         \
     case 2:  _hj_i += ( (unsigned)_hj_key[1] << 8 );   /* FALLTHROUGH */         \
-    case 1:  _hj_i += _hj_key[0];                                                \
+    case 1:  _hj_i += _hj_key[0];                      /* FALLTHROUGH */         \
+    default: ;                                         /* never reached */       \
   }                                                                              \
   HASH_JEN_MIX(_hj_i, _hj_j, hashv);                                             \
 } while (0)
@@ -743,6 +744,9 @@ do {                                                                            
     case 1: hashv += *_sfh_key;                                                  \
             hashv ^= hashv << 10;                                                \
             hashv += hashv >> 1;                                                 \
+            break;                                                               \
+    default:   /* never reached */                                               \
+            ;                                                                    \
   }                                                                              \
                                                                                  \
   /* Force "avalanching" of final 127 bits */                                    \


### PR DESCRIPTION
When compiling with -Wswitch-default, the state machine in HASH_JEN
and HASH_SFH cause compiler warnings due to a missing default cases.
This change adds the missing empty defaults.