### PR TITLE
Fix extra warnings

### DIFF
--- a/tests/sleep_test.c
+++ b/tests/sleep_test.c
@@ -9,7 +9,7 @@ typedef struct example_user_t {
     UT_hash_handle hh;
 } example_user_t;
 
-int main(int argc,char *argv[])
+int main(void)
 {
     int i;
     example_user_t *user, *users=NULL;

--- a/tests/test1.c
+++ b/tests/test1.c
@@ -8,7 +8,7 @@ typedef struct example_user_t {
     UT_hash_handle hh;
 } example_user_t;
 
-int main(int argc,char *argv[])
+int main(void)
 {
     int i;
     example_user_t *user, *users=NULL;

--- a/tests/test10.c
+++ b/tests/test10.c
@@ -9,7 +9,7 @@ typedef struct example_user_t {
     UT_hash_handle alth;
 } example_user_t;
 
-int main(int argc,char *argv[])
+int main(void)
 {
     int i;
     example_user_t *user, *tmp, *users=NULL, *altusers=NULL;

--- a/tests/test11.c
+++ b/tests/test11.c
@@ -25,7 +25,7 @@ static int namecmp(void *_a, void *_b)
     return strcmp(a->boy_name,b->boy_name);
 }
 
-int main(int argc,char *argv[])
+int main(void)
 {
     name_rec *name, *names=NULL;
     char linebuf[BUFLEN];

--- a/tests/test12.c
+++ b/tests/test12.c
@@ -8,7 +8,7 @@ typedef struct person_t {
     UT_hash_handle hh;
 } person_t;
 
-int main(int argc, char*argv[])
+int main(void)
 {
     person_t *people=NULL, *person;
     const char **name;

--- a/tests/test13.c
+++ b/tests/test13.c
@@ -8,7 +8,7 @@ typedef struct example_user_t {
     UT_hash_handle hh;
 } example_user_t;
 
-int main(int argc,char *argv[])
+int main(void)
 {
     int i;
     example_user_t *user, *tmp, *users=NULL;

--- a/tests/test14.c
+++ b/tests/test14.c
@@ -14,7 +14,7 @@ typedef struct name_rec {
     UT_hash_handle hh;
 } name_rec;
 
-int main(int argc,char *argv[])
+int main(void)
 {
     name_rec *name, *names=NULL;
     char linebuf[BUFLEN];

--- a/tests/test15.c
+++ b/tests/test15.c
@@ -10,7 +10,7 @@ struct my_struct {
 };
 
 
-int main(int argc, char *argv[])
+int main(void)
 {
     const char **n, *names[] = { "joe", "bob", "betty", NULL };
     struct my_struct *s, *tmp, *users = NULL;

--- a/tests/test16.c
+++ b/tests/test16.c
@@ -17,7 +17,7 @@ struct my_event {
 };
 
 
-int main(int argc, char *argv[])
+int main(void)
 {
     struct my_event *e, ev, *events = NULL;
     unsigned keylen;

--- a/tests/test17.c
+++ b/tests/test17.c
@@ -16,7 +16,7 @@ static int rev(void *_a, void *_b)
     return (a->id - b->id);
 }
 
-int main(int argc,char *argv[])
+int main(void)
 {
     int i;
     example_user_t *user, *users=NULL;

--- a/tests/test18.c
+++ b/tests/test18.c
@@ -8,7 +8,7 @@ typedef struct example_user_t {
     UT_hash_handle hh;
 } example_user_t;
 
-int main(int argc,char *argv[])
+int main(void)
 {
     int i;
     example_user_t *user, *users=NULL;

--- a/tests/test19.c
+++ b/tests/test19.c
@@ -29,7 +29,7 @@ static int descending_sort(void *_a, void *_b)
     return (a->id < b->id) ? 1 : -1;
 }
 
-int main(int argc,char *argv[])
+int main(void)
 {
     int i;
     example_user_t *user, *users=NULL, *altusers=NULL;

--- a/tests/test2.c
+++ b/tests/test2.c
@@ -9,7 +9,7 @@ typedef struct example_user_t {
     UT_hash_handle hh;
 } example_user_t;
 
-int main(int argc,char *argv[])
+int main(void)
 {
     int i;
     example_user_t *user, *tmp, *users=NULL;

--- a/tests/test20.c
+++ b/tests/test20.c
@@ -9,7 +9,7 @@ struct my_struct {
     UT_hash_handle hh;
 };
 
-int main(int argc, char *argv[])
+int main(void)
 {
     struct my_struct *s, *t, *bins = NULL;
     char binary[5] = {'\3','\1','\4','\1','\6'};

--- a/tests/test21.c
+++ b/tests/test21.c
@@ -13,7 +13,7 @@ typedef struct {
     UT_hash_handle hh;
 } record_t;
 
-int main(int argc, char *argv[])
+int main(void)
 {
     record_t l, *p, *r, *tmp, *records = NULL;
 

--- a/tests/test22.c
+++ b/tests/test22.c
@@ -18,7 +18,7 @@ typedef struct {
     int text[];
 } lookup_key_t;
 
-int main(int argc, char *argv[])
+int main(void)
 {
     unsigned keylen;
     msg_t *msg, *tmp, *msgs = NULL;

--- a/tests/test24.c
+++ b/tests/test24.c
@@ -8,7 +8,7 @@ typedef struct example_user_t {
     UT_hash_handle hh;
 } example_user_t;
 
-int main(int argc,char *argv[])
+int main(void)
 {
     int i;
     example_user_t *user, *users=NULL;

--- a/tests/test25.c
+++ b/tests/test25.c
@@ -6,7 +6,7 @@ typedef struct el {
     struct el *next, *prev;
 } el;
 
-int main(int argc, char *argv[])
+int main(void)
 {
     int i;
     int count;

--- a/tests/test26.c
+++ b/tests/test26.c
@@ -17,7 +17,7 @@ static int namecmp(void *_a, void *_b)
     return strcmp(a->bname,b->bname);
 }
 
-int main(int argc, char *argv[])
+int main(void)
 {
     el *name, *elt, *tmp, etmp;
     el *head = NULL; /* important- initialize to NULL! */

--- a/tests/test27.c
+++ b/tests/test27.c
@@ -6,7 +6,7 @@ typedef struct el {
     struct el *next, *prev;
 } el;
 
-int main(int argc, char *argv[])
+int main(void)
 {
     int i;
     el els[10], *e;

--- a/tests/test28.c
+++ b/tests/test28.c
@@ -6,7 +6,7 @@ typedef struct el {
     struct el *next, *prev;
 } el;
 
-int main(int argc, char *argv[])
+int main(void)
 {
     int i;
     el els[10], *e;

--- a/tests/test29.c
+++ b/tests/test29.c
@@ -17,7 +17,7 @@ static int namecmp(void *_a, void *_b)
     return strcmp(a->bname,b->bname);
 }
 
-int main(int argc, char *argv[])
+int main(void)
 {
     el *name, *tmp;
     el *head = NULL;

--- a/tests/test3.c
+++ b/tests/test3.c
@@ -8,7 +8,7 @@ typedef struct example_user_t {
     UT_hash_handle hh;
 } example_user_t;
 
-int main(int argc,char *argv[])
+int main(void)
 {
     int i;
     example_user_t *user, *tmp, *users=NULL;

--- a/tests/test30.c
+++ b/tests/test30.c
@@ -17,7 +17,7 @@ static int namecmp(void *_a, void *_b)
     return strcmp(a->bname,b->bname);
 }
 
-int main(int argc, char *argv[])
+int main(void)
 {
     el *name, *tmp;
     el *head = NULL;

--- a/tests/test31.c
+++ b/tests/test31.c
@@ -17,7 +17,7 @@ static int namecmp(void *_a, void *_b)
     return strcmp(a->bname,b->bname);
 }
 
-int main(int argc, char *argv[])
+int main(void)
 {
     el *name, *tmp;
     el *head = NULL;

--- a/tests/test32.c
+++ b/tests/test32.c
@@ -10,7 +10,7 @@ typedef struct el {
     struct el *next, *prev;
 } el;
 
-int main(int argc, char *argv[])
+int main(void)
 {
     el *name, *tmp;
     el *head = NULL;

--- a/tests/test33.c
+++ b/tests/test33.c
@@ -17,7 +17,7 @@ static int namecmp(void *_a, void *_b)
     return strcmp(a->bname,b->bname);
 }
 
-int main(int argc, char *argv[])
+int main(void)
 {
     el *name, *tmp;
     el *head = NULL;

--- a/tests/test34.c
+++ b/tests/test34.c
@@ -10,7 +10,7 @@ typedef struct el {
     struct el *next, *prev;
 } el;
 
-int main(int argc, char *argv[])
+int main(void)
 {
     el *name, *tmp;
     el *head = NULL;

--- a/tests/test35.c
+++ b/tests/test35.c
@@ -8,7 +8,7 @@ typedef struct elt {
     UT_hash_handle hh;
 } elt;
 
-int main(int argc,char *argv[])
+int main(void)
 {
     int i;
     elt *head = NULL;

--- a/tests/test36.c
+++ b/tests/test36.c
@@ -22,7 +22,7 @@ static int idcmp(void *_a, void *_b)
     return (a->id - b->id);
 }
 
-int main(int argc,char *argv[])
+int main(void)
 {
     int i;
     example_user_t *user, *users=NULL, *ausers=NULL;

--- a/tests/test37.c
+++ b/tests/test37.c
@@ -17,7 +17,7 @@ static int idcmp(void *_a, void *_b)
     return (a->id - b->id);
 }
 
-int main(int argc,char *argv[])
+int main(void)
 {
     int i;
     example_user_t *user, *users=NULL, *ausers=NULL;

--- a/tests/test4.c
+++ b/tests/test4.c
@@ -9,7 +9,7 @@ typedef struct example_user_t {
     UT_hash_handle alth;
 } example_user_t;
 
-int main(int argc,char *argv[])
+int main(void)
 {
     int i;
     example_user_t *user, *users=NULL, *altusers=NULL;

--- a/tests/test40.c
+++ b/tests/test40.c
@@ -10,7 +10,7 @@ struct my_struct {
 };
 
 
-int main(int argc, char *argv[])
+int main(void)
 {
     const char **n, *names[] = { "joe", "bob", "betty", NULL };
     struct my_struct *s, *tmp, *users = NULL;

--- a/tests/test41.c
+++ b/tests/test41.c
@@ -6,7 +6,7 @@ typedef struct el {
     struct el *next, *prev;
 } el;
 
-int main(int argc, char *argv[])
+int main(void)
 {
     int i;
     el *head = NULL;

--- a/tests/test42.c
+++ b/tests/test42.c
@@ -11,7 +11,7 @@ static int eltcmp(el *a, el *b)
     return a->id - b->id;
 }
 
-int main(int argc, char *argv[])
+int main(void)
 {
     int i;
     el *head = NULL;

--- a/tests/test5.c
+++ b/tests/test5.c
@@ -9,7 +9,7 @@ typedef struct example_user_t {
     UT_hash_handle alth;
 } example_user_t;
 
-int main(int argc,char *argv[])
+int main(void)
 {
     int i,j;
     example_user_t *user, *tmp, *users=NULL, *altusers=NULL;

--- a/tests/test56.c
+++ b/tests/test56.c
@@ -25,7 +25,7 @@ static int namecmp(void *_a, void *_b)
     return strcmp(a->bname,b->bname);
 }
 
-int main(int argc, char *argv[])
+int main(void)
 {
     el *name, *elt, *tmp, etmp;
     int i;

--- a/tests/test58.c
+++ b/tests/test58.c
@@ -8,7 +8,7 @@ typedef struct example_user_t {
     UT_hash_handle hh;
 } example_user_t;
 
-int main(int argc,char *argv[])
+int main(void)
 {
     int i;
     unsigned c;

--- a/tests/test59.c
+++ b/tests/test59.c
@@ -11,7 +11,7 @@ typedef struct item {
     UT_hash_handle hh;
 } item_t;
 
-int main(int argc, char *argvp[])
+int main(void)
 {
     item_t *item1, *item2, *tmp1, *tmp2;
     item_t *items=NULL;

--- a/tests/test6.c
+++ b/tests/test6.c
@@ -78,7 +78,7 @@ static void real_free(void *p)
 #define memcmp ..fail_to_compile..
 #define strlen ..fail_to_compile..
 
-int main(int argc,char *argv[])
+int main(void)
 {
     int i;
     example_user_t *user, *tmp, *users=NULL;

--- a/tests/test60.c
+++ b/tests/test60.c
@@ -11,7 +11,7 @@ typedef struct item {
     UT_hash_handle hh;
 } item_t;
 
-int main(int argc, char *argvp[])
+int main(void)
 {
     item_t *item1, *item2, *tmp1, *tmp2;
     item_t *items=NULL;

--- a/tests/test62.c
+++ b/tests/test62.c
@@ -8,7 +8,7 @@
 unsigned int TrivialHash(const char *s, size_t len)
 {
     unsigned int h = 0;
-    int i;
+    size_t i;
     for (i=0; i < len; ++i) {
         h += (unsigned char)s[i];
     }

--- a/tests/test63.c
+++ b/tests/test63.c
@@ -6,7 +6,7 @@ typedef struct el {
     struct el *next, *prev;
 } el;
 
-int main(int argc, char *argv[])
+int main(void)
 {
     int i;
     el els[10], *e;

--- a/tests/test64.c
+++ b/tests/test64.c
@@ -6,7 +6,7 @@ typedef struct el {
     struct el *next, *prev;
 } el;
 
-int main(int argc, char *argv[])
+int main(void)
 {
     int i;
     el els[10], *e;

--- a/tests/test66.c
+++ b/tests/test66.c
@@ -8,7 +8,7 @@ typedef struct person_t {
     UT_hash_handle hh;
 } person_t;
 
-int main(int argc, char*argv[])
+int main(void)
 {
     person_t *people=NULL, *person;
     const char **name;

--- a/tests/test68.c
+++ b/tests/test68.c
@@ -7,7 +7,7 @@ typedef struct el {
     struct el *next, *prev;
 } el;
 
-int main(int argc, char *argv[])
+int main(void)
 {
     int i;
     el els[20], *e, *tmp;

--- a/tests/test69.c
+++ b/tests/test69.c
@@ -7,7 +7,7 @@ typedef struct el {
     struct el *next, *prev;
 } el;
 
-int main(int argc, char *argv[])
+int main(void)
 {
     int i;
     el els[26], *e, *tmp;

--- a/tests/test7.c
+++ b/tests/test7.c
@@ -9,7 +9,7 @@ typedef struct example_user_t {
     UT_hash_handle hh;
 } example_user_t;
 
-int main(int argc,char *argv[])
+int main(void)
 {
     int i;
     example_user_t *user, *tmp, *users=NULL;

--- a/tests/test70.c
+++ b/tests/test70.c
@@ -7,7 +7,7 @@ typedef struct el {
     struct el *next, *prev;
 } el;
 
-int main(int argc, char *argv[])
+int main(void)
 {
     int i;
     el els[20], *e, *tmp;

--- a/tests/test71.c
+++ b/tests/test71.c
@@ -7,7 +7,7 @@ typedef struct el {
     struct el *next, *prev;
 } el;
 
-int main(int argc, char *argv[])
+int main(void)
 {
     int i;
     el els[26], *e, *tmp;

--- a/tests/test72.c
+++ b/tests/test72.c
@@ -7,7 +7,7 @@ typedef struct el {
     struct el *next, *prev;
 } el;
 
-int main(int argc, char *argv[])
+int main(void)
 {
     int i;
     el els[20], *e, *tmp, *tmp2;

--- a/tests/test73.c
+++ b/tests/test73.c
@@ -7,7 +7,7 @@ typedef struct el {
     struct el *next, *prev;
 } el;
 
-int main(int argc, char *argv[])
+int main(void)
 {
     int i;
     el els[26], *e, *tmp, *tmp2;

--- a/tests/test78.c
+++ b/tests/test78.c
@@ -6,7 +6,7 @@ typedef struct el {
     struct el *Next, *Prev;
 } el;
 
-int main(int argc, char *argv[])
+int main(void)
 {
     int i;
     el els[10], *e;

--- a/tests/test79.c
+++ b/tests/test79.c
@@ -17,7 +17,7 @@ static void pr(hs_t **hdpp)
     }
 }
 
-int main(int argc, char *argv[])
+int main(void)
 {
 
     hs_t *hs_head=NULL, *tmp, *replaced=NULL;

--- a/tests/test8.c
+++ b/tests/test8.c
@@ -8,7 +8,7 @@ typedef struct example_user_t {
     UT_hash_handle hh;
 } example_user_t;
 
-int main(int argc,char *argv[])
+int main(void)
 {
     int i;
     example_user_t *user, *tmp, *users=NULL;

--- a/tests/test83.c
+++ b/tests/test83.c
@@ -8,7 +8,7 @@ typedef struct person_t {
     UT_hash_handle hh;
 } person_t;
 
-int main(int argc, char*argv[])
+int main(void)
 {
     person_t *people=NULL, *person, *new_person, *tmp;
     const char **name;

--- a/tests/test84.c
+++ b/tests/test84.c
@@ -8,7 +8,7 @@ typedef struct person_t {
     UT_hash_handle hh;
 } person_t;
 
-int main(int argc, char*argv[])
+int main(void)
 {
     person_t *people=NULL, *person, *new_person, *tmp;
     const char **name;

--- a/tests/test85.c
+++ b/tests/test85.c
@@ -8,7 +8,7 @@ typedef struct example_user_t {
     UT_hash_handle hh;
 } example_user_t;
 
-int main(int argc,char *argv[])
+int main(void)
 {
     int i;
     example_user_t *user, *users=NULL;

--- a/tests/test86.c
+++ b/tests/test86.c
@@ -6,7 +6,7 @@ typedef struct el {
     struct el *next, *prev;
 } el;
 
-int main(int argc, char *argv[])
+int main(void)
 {
     int i;
     int count;

--- a/tests/test88.c
+++ b/tests/test88.c
@@ -31,7 +31,7 @@ static size_t alt_strlen(const char *s)
     return strlen(s);
 }
 
-int main(int argc,char *argv[])
+int main(void)
 {
     int i;
     example_user_t *user, *tmp, *users=NULL;

--- a/tests/test9.c
+++ b/tests/test9.c
@@ -8,7 +8,7 @@ typedef struct example_user_t {
     UT_hash_handle hh;
 } example_user_t;
 
-int main(int argc,char *argv[])
+int main(void)
 {
     int i;
     example_user_t *user, *tmp, *users=NULL;

--- a/tests/test91.c
+++ b/tests/test91.c
@@ -11,7 +11,7 @@ static int order_desc(el *a, el *b)
     return (a->score > b->score) ? -1 : (a->score < b->score);
 }
 
-int main(int argc, char *argv[])
+int main(void)
 {
     int i;
     el *head = NULL;

--- a/tests/test92.c
+++ b/tests/test92.c
@@ -56,7 +56,7 @@ static void complain(int index, example_user_t *users, example_user_t *user)
     }
 }
 
-int main(int argc, char *argv[])
+int main(void)
 {
     example_user_t *users = NULL;
     example_user_t *user = (example_user_t*)malloc(sizeof(example_user_t));

--- a/tests/test93.c
+++ b/tests/test93.c
@@ -34,6 +34,7 @@ static void *alt_malloc(size_t sz)
 }
 
 static void alt_fatal(char const * s) {
+    (void)s;
     is_fatal = 1;
     longjmp(j_buf, 1);
 }
@@ -51,7 +52,7 @@ static example_user_t * init_user(int need_malloc_cnt) {
     return user;
 }
 
-int main(int argc, char *argv[])
+int main(void)
 {
 
 #define init(a) do { \

--- a/tests/test94.c
+++ b/tests/test94.c
@@ -17,7 +17,7 @@ static int order_asc(el *a, el *b)
     return -order_desc(a, b);
 }
 
-int main(int argc, char *argv[])
+int main(void)
 {
     int i;
     el *head = NULL;


### PR DESCRIPTION
When compiling the unit tests with `-Wextra` several compiler warnings are output due to unused arguments—in one case—signedness of variables. Both types of warnings are fixed by this PR.

Testing: `make EXTRA_CFLAGS="-Wextra"`.

Not fixed by this PR are additional warnings emitted from gcc regarding the limits of data types (`-Wtype-limits`), cf. `make EXTRA_CFLAGS="-Wextra" CC=gcc`. (These warnings occur in `utarray.h` and indicate dead branches.)