### PR TITLE
Set up TravisCI for continuous testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: cpp
+compiler:
+- clang
+- gcc
+script:
+- make -C tests
+- make -C tests pedantic
+- make -C tests pedantic EXTRA_CFLAGS=-DNO_DECLTYPE
+- make -C tests cplusplus
+- make -C tests cplusplus EXTRA_CFLAGS=-DNO_DECLTYPE

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 
+[![Build status](https://travis-ci.org/Quuxplusone/uthash.svg?branch=travis-ci)](https://travis-ci.org/troydhanson/uthash)
+
 Documentation for uthash is available at:
 
 http://troydhanson.github.com/uthash/


### PR DESCRIPTION
@troydhanson: I vaguely recall that I've made noises about trying to set up TravisCI before. (This patch is from March 2017!) But it looks like I've never made an official PR for it before now.

In order to set it up for automatic testing of pull requests, it needs one thing from you: you have to go to https://travis-ci.org/troydhanson/uthash and give them permission to pull from this repo and send you email when the build breaks. (Or maybe you can figure out how to get them to send _me_ email when the build breaks; I'm cool with that, if it's possible.)

I probably didn't push hard for TravisCI three years ago because I didn't like giving out permissions even for simple stuff; but since then, I've used TravisCI extensively, in repos such as https://github.com/zenorogue/hyperrogue and https://github.com/WG21-SG14/SG14, and I've never had any reason to regret it.