### PR TITLE
Support spaces in $exe path

### DIFF
--- a/tests/keystats
+++ b/tests/keystats
@@ -12,9 +12,11 @@ sub usage {
 
 usage if ((@ARGV == 0) or ($ARGV[0] eq '-h'));
 
-my @exes = glob "$FindBin::Bin/keystat.???";
+my @exes = glob "'$FindBin::Bin/keystat.???'";
+
 my %stats;
 for my $exe (@exes) {
+    $exe =~ s/\ /\\ /g;
     $stats{$exe} = `$exe @ARGV`;
     delete $stats{$exe} if ($? != 0); # omit hash functions that fail to produce stats (nx)
 }


### PR DESCRIPTION
If uthash is cloned under a path with spaces, it doesn't run the keyscan.* files.