### PR TITLE
Support linting using BSD lint(1).

### DIFF
--- a/src/uthash.h
+++ b/src/uthash.h
@@ -74,6 +74,8 @@ typedef unsigned char uint8_t;
 #endif
 #elif defined(__GNUC__) && !defined(__VXWORKS__)
 #include <stdint.h>
+#elif defined(__lint__)
+#include <stdint.h>
 #else
 typedef unsigned int uint32_t;
 typedef unsigned char uint8_t;


### PR DESCRIPTION
Change the preprocessing logic in uthash.h to
include the C99 header <stdint.h> when the file
is being analyzed by lint(1).
