### PR TITLE
Always include <stdint.h>, unless HASH_NO_STDINT is defined by the user.

### DIFF
--- a/src/uthash.h
+++ b/src/uthash.h
@@ -30,6 +30,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stddef.h>   /* ptrdiff_t */
 #include <stdlib.h>   /* exit */
 
+#if defined(HASH_NO_STDINT) && HASH_NO_STDINT
+#elif defined(HASH_DEFINE_OWN_STDINT) && HASH_DEFINE_OWN_STDINT
+typedef unsigned int uint32_t;
+typedef unsigned char uint8_t;
+#else
+#include <stdint.h>   /* uint8_t, uint32_t */
+#endif
+
 /* These macros use decltype or the earlier __typeof GNU extension.
    As decltype is only available in newer compilers (VS2010 or gcc 4.3+
    when compiling c++ source) this code uses whatever method is needed
@@ -60,23 +68,6 @@ do {                                                                            
 do {                                                                             \
   (dst) = DECLTYPE(dst)(src);                                                    \
 } while (0)
-#endif
-
-/* a number of the hash function use uint32_t which isn't defined on Pre VS2010 */
-#if defined(_WIN32)
-#if defined(_MSC_VER) && _MSC_VER >= 1600
-#include <stdint.h>
-#elif defined(__WATCOMC__) || defined(__MINGW32__) || defined(__CYGWIN__)
-#include <stdint.h>
-#else
-typedef unsigned int uint32_t;
-typedef unsigned char uint8_t;
-#endif
-#elif defined(__GNUC__) && !defined(__VXWORKS__)
-#include <stdint.h>
-#else
-typedef unsigned int uint32_t;
-typedef unsigned char uint8_t;
 #endif
 
 #ifndef uthash_malloc


### PR DESCRIPTION
See 762026ce and b1d8ab07 for previous attempts (circa 2014-2015) to detect whether it's OK to use <stdint.h>; and see #211 for how that logic is still incomplete.

Rather than continue down this path, how about we just say that either your system should be C99 (it's the year 2020!), _or_ you should provide your own "polyfill" version of `<stdint.h>` in the normal search path, _or_ you should `-DHASH_NO_STDINT` and figure out the details yourself (e.g. by providing the necessary typedefs above where you `#include <uthash.h>`).

Also support `-DHASH_DEFINE_OWN_STDINT` for this next release, so that there's an easy backward-compatibility mode. I might rip out this mode in the release after next, though.

@tbeu: please take a look, since you're the author of much of this logic (back in 2014-2015). Any objection to my thus ripping it out?