### PR TITLE
Bump version to 2.2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2005-2018, Troy D. Hanson    http://troydhanson.github.com/uthash/
+Copyright (c) 2005-2020, Troy D. Hanson    http://troydhanson.github.com/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/doc/ChangeLog.txt
+++ b/doc/ChangeLog.txt
@@ -5,6 +5,15 @@ Click to return to the link:index.html[uthash home page].
 
 NOTE: This ChangeLog may be incomplete and/or incorrect. See the git commit log.
 
+Version 2.2.0 (2020-12-??)
+--------------------------
+* add HASH_NO_STDINT for platforms without C99 <stdint.h>
+* silence many -Wcast-qual warnings (thanks, Olaf Bergmann!)
+* skip hash computation when finding in an empty hash (thanks, Huansong Fu!)
+* rename oom to utarray_oom, in utarray.h (thanks, Hong Xu!)
+* rename oom to utstring_oom, in utstring.h (thanks, Hong Xu!)
+* remove MurmurHash/HASH_MUR
+
 Version 2.1.0 (2018-12-20)
 --------------------------
 * silence some Clang static analysis warnings

--- a/doc/license.html
+++ b/doc/license.html
@@ -21,7 +21,7 @@
   <div id="mid">
       <div id="main">
 <pre>
-Copyright (c) 2005-2018, Troy D. Hanson  http://troydhanson.github.com/uthash/
+Copyright (c) 2005-2020, Troy D. Hanson  http://troydhanson.github.com/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/doc/userguide.txt
+++ b/doc/userguide.txt
@@ -1,7 +1,7 @@
 uthash User Guide
 =================
 Troy D. Hanson, Arthur O'Dwyer
-v2.1.0, December 2018
+v2.2.0, December 2020
 
 To download uthash, follow this link back to the
 https://github.com/troydhanson/uthash[GitHub project page].

--- a/doc/utarray.txt
+++ b/doc/utarray.txt
@@ -1,7 +1,7 @@
 utarray: dynamic array macros for C
 ===================================
 Troy D. Hanson <tdh@tkhanson.net>
-v2.1.0, December 2018
+v2.2.0, December 2020
 
 Here's a link back to the https://github.com/troydhanson/uthash[GitHub project page].
 

--- a/doc/utlist.txt
+++ b/doc/utlist.txt
@@ -1,7 +1,7 @@
 utlist: linked list macros for C structures
 ===========================================
 Troy D. Hanson <tdh@tkhanson.net>
-v2.1.0, December 2018
+v2.2.0, December 2020
 
 Here's a link back to the https://github.com/troydhanson/uthash[GitHub project page].
 

--- a/doc/utringbuffer.txt
+++ b/doc/utringbuffer.txt
@@ -1,7 +1,7 @@
 utringbuffer: dynamic ring-buffer macros for C
 ==============================================
 Arthur O'Dwyer <arthur.j.odwyer@gmail.com>
-v2.1.0, December 2018
+v2.2.0, December 2020
 
 Here's a link back to the https://github.com/troydhanson/uthash[GitHub project page].
 

--- a/doc/utstack.txt
+++ b/doc/utstack.txt
@@ -1,7 +1,7 @@
 utstack: intrusive stack macros for C
 =====================================
 Arthur O'Dwyer <arthur.j.odwyer@gmail.com>
-v2.1.0, December 2018
+v2.2.0, December 2020
 
 Here's a link back to the https://github.com/troydhanson/uthash[GitHub project page].
 

--- a/doc/utstring.txt
+++ b/doc/utstring.txt
@@ -1,7 +1,7 @@
 utstring: dynamic string macros for C
 =====================================
 Troy D. Hanson <tdh@tkhanson.net>
-v2.1.0, December 2018
+v2.2.0, December 2020
 
 Here's a link back to the https://github.com/troydhanson/uthash[GitHub project page].
 

--- a/package.json
+++ b/package.json
@@ -24,5 +24,5 @@
     "src/utstring.h"
   ],
 
-  "version": "2.1.0"
+  "version": "2.2.0"
 }

--- a/src/utarray.h
+++ b/src/utarray.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2008-2018, Troy D. Hanson   http://troydhanson.github.com/uthash/
+Copyright (c) 2008-2020, Troy D. Hanson   http://troydhanson.github.com/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef UTARRAY_H
 #define UTARRAY_H
 
-#define UTARRAY_VERSION 2.1.0
+#define UTARRAY_VERSION 2.2.0
 
 #include <stddef.h>  /* size_t */
 #include <string.h>  /* memset, etc */

--- a/src/uthash.h
+++ b/src/uthash.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2003-2018, Troy D. Hanson     http://troydhanson.github.com/uthash/
+Copyright (c) 2003-2020, Troy D. Hanson     http://troydhanson.github.com/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,7 +24,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef UTHASH_H
 #define UTHASH_H
 
-#define UTHASH_VERSION 2.1.0
+#define UTHASH_VERSION 2.2.0
 
 #include <string.h>   /* memcmp, memset, strlen */
 #include <stddef.h>   /* ptrdiff_t */

--- a/src/utlist.h
+++ b/src/utlist.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2007-2018, Troy D. Hanson   http://troydhanson.github.com/uthash/
+Copyright (c) 2007-2020, Troy D. Hanson   http://troydhanson.github.com/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,7 +24,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef UTLIST_H
 #define UTLIST_H
 
-#define UTLIST_VERSION 2.1.0
+#define UTLIST_VERSION 2.2.0
 
 #include <assert.h>
 

--- a/src/utringbuffer.h
+++ b/src/utringbuffer.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015-2018, Troy D. Hanson   http://troydhanson.github.com/uthash/
+Copyright (c) 2015-2020, Troy D. Hanson   http://troydhanson.github.com/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef UTRINGBUFFER_H
 #define UTRINGBUFFER_H
 
-#define UTRINGBUFFER_VERSION 2.1.0
+#define UTRINGBUFFER_VERSION 2.2.0
 
 #include <stdlib.h>
 #include <string.h>

--- a/src/utstack.h
+++ b/src/utstack.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2018-2018, Troy D. Hanson   http://troydhanson.github.com/uthash/
+Copyright (c) 2018-2020, Troy D. Hanson   http://troydhanson.github.com/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,7 +24,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef UTSTACK_H
 #define UTSTACK_H
 
-#define UTSTACK_VERSION 2.1.0
+#define UTSTACK_VERSION 2.2.0
 
 /*
  * This file contains macros to manipulate a singly-linked list as a stack.

--- a/src/utstring.h
+++ b/src/utstring.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2008-2018, Troy D. Hanson   http://troydhanson.github.com/uthash/
+Copyright (c) 2008-2020, Troy D. Hanson   http://troydhanson.github.com/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef UTSTRING_H
 #define UTSTRING_H
 
-#define UTSTRING_VERSION 2.1.0
+#define UTSTRING_VERSION 2.2.0
 
 #include <stdlib.h>
 #include <string.h>

--- a/tests/hashscan.c
+++ b/tests/hashscan.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2005-2018, Troy D. Hanson    http://troydhanson.github.com/uthash/
+Copyright (c) 2005-2020, Troy D. Hanson    http://troydhanson.github.com/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
TODO:
- Update the date in doc/ChangeLog.txt
- `git tag v2.2.0`
- Close #205 as fixed

@troydhanson @tstruk @tbeu: please take a look. I'm currently planning to land this "by Christmas," unless I hear some objection.