### PR TITLE
Replace *.github.com urls with *.github.io

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2005-2021, Troy D. Hanson    http://troydhanson.github.com/uthash/
+Copyright (c) 2005-2021, Troy D. Hanson    http://troydhanson.github.io/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 
 Documentation for uthash is available at:
 
-https://troydhanson.github.com/uthash/
+https://troydhanson.github.io/uthash/
 
 

--- a/doc/license.html
+++ b/doc/license.html
@@ -13,7 +13,7 @@
   </div> <!-- banner -->
 
   <div id="topnav">
-  <a href="http://troydhanson.github.com/uthash/">uthash home</a> &gt;
+  <a href="http://troydhanson.github.io/uthash/">uthash home</a> &gt;
   BSD license
   </div>
 
@@ -21,7 +21,7 @@
   <div id="mid">
       <div id="main">
 <pre>
-Copyright (c) 2005-2021, Troy D. Hanson  http://troydhanson.github.com/uthash/
+Copyright (c) 2005-2021, Troy D. Hanson  http://troydhanson.github.io/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/utarray.h
+++ b/src/utarray.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2008-2021, Troy D. Hanson   http://troydhanson.github.com/uthash/
+Copyright (c) 2008-2021, Troy D. Hanson   http://troydhanson.github.io/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/uthash.h
+++ b/src/uthash.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2003-2021, Troy D. Hanson     http://troydhanson.github.com/uthash/
+Copyright (c) 2003-2021, Troy D. Hanson     http://troydhanson.github.io/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/utlist.h
+++ b/src/utlist.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2007-2021, Troy D. Hanson   http://troydhanson.github.com/uthash/
+Copyright (c) 2007-2021, Troy D. Hanson   http://troydhanson.github.io/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/utringbuffer.h
+++ b/src/utringbuffer.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015-2021, Troy D. Hanson   http://troydhanson.github.com/uthash/
+Copyright (c) 2015-2021, Troy D. Hanson   http://troydhanson.github.io/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/utstack.h
+++ b/src/utstack.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2018-2021, Troy D. Hanson   http://troydhanson.github.com/uthash/
+Copyright (c) 2018-2021, Troy D. Hanson   http://troydhanson.github.io/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/utstring.h
+++ b/src/utstring.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2008-2021, Troy D. Hanson   http://troydhanson.github.com/uthash/
+Copyright (c) 2008-2021, Troy D. Hanson   http://troydhanson.github.io/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/tests/hashscan.c
+++ b/tests/hashscan.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2005-2021, Troy D. Hanson    http://troydhanson.github.com/uthash/
+Copyright (c) 2005-2021, Troy D. Hanson    http://troydhanson.github.io/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/tests/test65.c
+++ b/tests/test65.c
@@ -3,7 +3,7 @@
 #include "uthash.h"
 
 // this is an example of how to do a LRU cache in C using uthash
-// http://troydhanson.github.com/uthash/
+// http://troydhanson.github.io/uthash/
 // by Jehiah Czebotar 2011 - jehiah@gmail.com
 // this code is in the public domain http://unlicense.org/
 


### PR DESCRIPTION
GitHub is ending the *.github.com redirects in April. Use *.github.io instead.