### PR TITLE
Fix typo in userguide

### DIFF
--- a/userguide.html
+++ b/userguide.html
@@ -1576,7 +1576,7 @@ int main(int argc, char *argv[]) {
         s = (struct my_struct *)malloc(sizeof *s);
         strcpy(s-&gt;name, names[i]);
         s-&gt;id = i;
-        HASH_ADD_STR(users, name, s);
+        HASH_ADD_STR(users, s-&gt;name, s);
     }
 
     HASH_FIND_STR(users, "betty", s);


### PR DESCRIPTION
Hello,

I have been reading the user guide and I found a typo in this example.
Otherwise `name` is not defined