### PR TITLE
replace gets by fgets

### DIFF
--- a/tests/example.c
+++ b/tests/example.c
@@ -14,39 +14,15 @@ struct my_struct {
 struct my_struct *users = NULL;
 
 char *get_input() {
-  char *entry=NULL;
-  char *newline;
-  static char entry_buffer[NAME_SIZE];
-
-  entry = fgets(entry_buffer, sizeof(entry_buffer), stdin); // Read entry
-  if (entry==NULL) {
-    printf("ENTRY NULL\n");
-    return NULL;
-  } else {
-    // Clean entry from newline
-    newline = strchr(entry, '\n');
-    if (newline!=NULL) {
-      *newline = '\0';
-    } else {
-      // Clear entry
-      printf("Entry is too long\n");
-      while (1) {
-	entry = fgets(entry_buffer, sizeof(entry_buffer), stdin); // Read entry
-	// Exit on error
-	if ((entry[0]=='\0') || (entry[0]=='\n') || (entry==NULL) || feof(stdin)) {
-	  entry = NULL;
-	  break;
-	}
-	newline = strchr(entry, '\n');
-	if (newline!=NULL) {
-	  entry=NULL;
-	  break;
-	}
-      }
+    static char buf[NAME_SIZE];
+    printf("99 char max> "); fflush(stdout);
+    char *p = fgets(buf, sizeof(buf), stdin);
+    if (p == NULL || (p = strchr(buf, '\n')) == NULL) {
+        puts("Invalid input!");
+        exit(EXIT_FAILURE);
     }
-  }
-
-  return entry;
+    *p = '\0';
+    return buf;
 }
 
 void add_user(int user_id, char *name)
@@ -121,6 +97,7 @@ int main()
     int id = 1, running = 1;
     struct my_struct *s;
     unsigned num_users;
+    atexit(delete_all);
 
     while (running) {
         printf(" 1. add user\n");
@@ -135,35 +112,29 @@ int main()
         printf("10. quit\n");
 
 	in = get_input();
-	if (in==NULL) { printf("Invalid entry\n"); continue; }
         switch(atoi(in)) {
             case 1:
                 printf("name?\n");
 		in = get_input();
-		if (in==NULL) { printf("Invalid entry\n"); continue; }
                 add_user(id++, in);
                 break;
             case 2:
                 printf("id?\n");
 		in = get_input();
-		if (in==NULL) { printf("Invalid entry\n"); continue; }
                 id = atoi(in);
                 printf("name?\n");
 		in = get_input();
-		if (in==NULL) { printf("Invalid entry\n"); continue; }
                 add_user(id, in);
                 break;
             case 3:
                 printf("id?\n");
 		in = get_input();
-		if (in==NULL) { printf("Invalid entry\n"); continue; }
                 s = find_user(atoi(in));
                 printf("user: %s\n", s ? s->name : "unknown");
                 break;
             case 4:
                 printf("id?\n");
 		in = get_input();
-		if (in==NULL) { printf("Invalid entry\n"); continue; }
                 s = find_user(atoi(in));
                 if (s) {
                     delete_user(s);

--- a/tests/example.c
+++ b/tests/example.c
@@ -3,13 +3,51 @@
 #include <string.h>  /* strcpy */
 #include "uthash.h"
 
+#define NAME_SIZE 100
+
 struct my_struct {
     int id;                    /* key */
-    char name[10];
+    char name[NAME_SIZE];
     UT_hash_handle hh;         /* makes this structure hashable */
 };
 
 struct my_struct *users = NULL;
+
+char *get_input() {
+  char *entry=NULL;
+  char *newline;
+  static char entry_buffer[NAME_SIZE];
+
+  entry = fgets(entry_buffer, sizeof(entry_buffer), stdin); // Read entry
+  if (entry==NULL) {
+    printf("ENTRY NULL\n");
+    return NULL;
+  } else {
+    // Clean entry from newline
+    newline = strchr(entry, '\n');
+    if (newline!=NULL) {
+      *newline = '\0';
+    } else {
+      // Clear entry
+      printf("Entry is too long\n");
+      while (1) {
+	entry = fgets(entry_buffer, sizeof(entry_buffer), stdin); // Read entry
+	// Exit on error
+	if ((entry[0]=='\0') || (entry[0]=='\n') || (entry==NULL) || feof(stdin)) {
+	  entry = NULL;
+	  break;
+	}
+	newline = strchr(entry, '\n');
+	if (newline!=NULL) {
+	  entry=NULL;
+	  break;
+	}
+      }
+    }
+  }
+
+  return entry;
+}
 
 void add_user(int user_id, char *name)
 {
@@ -79,7 +117,7 @@ void sort_by_id()
 
 int main()
 {
-    char in[10];
+    char *in;
     int id = 1, running = 1;
     struct my_struct *s;
     unsigned num_users;
@@ -95,27 +133,38 @@ int main()
         printf(" 8. print users\n");
         printf(" 9. count users\n");
         printf("10. quit\n");
-        gets(in);
+
+	in = get_input();
+	if (in==NULL) { printf("Invalid entry\n"); continue; }
         switch(atoi(in)) {
             case 1:
                 printf("name?\n");
-                add_user(id++, gets(in));
+		in = get_input();
+		if (in==NULL) { printf("Invalid entry\n"); continue; }
+                add_user(id++, in);
                 break;
             case 2:
                 printf("id?\n");
-                gets(in);
+		in = get_input();
+		if (in==NULL) { printf("Invalid entry\n"); continue; }
                 id = atoi(in);
                 printf("name?\n");
-                add_user(id, gets(in));
+		in = get_input();
+		if (in==NULL) { printf("Invalid entry\n"); continue; }
+                add_user(id, in);
                 break;
             case 3:
                 printf("id?\n");
-                s = find_user(atoi(gets(in)));
+		in = get_input();
+		if (in==NULL) { printf("Invalid entry\n"); continue; }
+                s = find_user(atoi(in));
                 printf("user: %s\n", s ? s->name : "unknown");
                 break;
             case 4:
                 printf("id?\n");
-                s = find_user(atoi(gets(in)));
+		in = get_input();
+		if (in==NULL) { printf("Invalid entry\n"); continue; }
+                s = find_user(atoi(in));
                 if (s) {
                     delete_user(s);
                 } else {

--- a/tests/example.c
+++ b/tests/example.c
@@ -13,8 +13,8 @@ struct my_struct {
 
 struct my_struct *users = NULL;
 
-char *get_input() {
-    static char buf[NAME_SIZE];
+const char *get_input() {
+    static char buf[100];
     printf("99 char max> "); fflush(stdout);
     char *p = fgets(buf, sizeof(buf), stdin);
     if (p == NULL || (p = strchr(buf, '\n')) == NULL) {
@@ -25,7 +25,7 @@ char *get_input() {
     return buf;
 }
 
-void add_user(int user_id, char *name)
+void add_user(int user_id, const char *name)
 {
     struct my_struct *s;
 
@@ -93,7 +93,7 @@ void sort_by_id()
 
 int main()
 {
-    char *in;
+    const char *in;
     int id = 1, running = 1;
     struct my_struct *s;
     unsigned num_users;

--- a/tests/example.c
+++ b/tests/example.c
@@ -14,7 +14,7 @@ struct my_struct {
 struct my_struct *users = NULL;
 
 const char *get_input() {
-    static char buf[100];
+    static char buf[NAME_SIZE];
     printf("99 char max> "); fflush(stdout);
     char *p = fgets(buf, sizeof(buf), stdin);
     if (p == NULL || (p = strchr(buf, '\n')) == NULL) {


### PR DESCRIPTION
add function get_input that relies on fgets to accept input up to a
fixed length.

In this PR, I tried a minimal revision of example.c to remove gets. Every call to gets
is replaced by `in = get_input()` (`in` being now a `char *`) and a check for `in==NULL`.

I tried to make `get_input` robust to overlong line (shows "Entry too long" and clears input buffer).

If the idea of a minimal rewrite is not good, as you hinted at in #228 , don't bother commenting
in detail, I would give it a try with a different type of program.