### PR TITLE
Fix -Wimplicit-fallthrough warnings

### DIFF
--- a/src/uthash.h
+++ b/src/uthash.h
@@ -668,17 +668,28 @@ do {                                                                            
   }                                                                              \
   hashv += (unsigned)(keylen);                                                   \
   switch ( _hj_k ) {                                                             \
-    case 11: hashv += ( (unsigned)_hj_key[10] << 24 ); /* FALLTHROUGH */         \
-    case 10: hashv += ( (unsigned)_hj_key[9] << 16 );  /* FALLTHROUGH */         \
-    case 9:  hashv += ( (unsigned)_hj_key[8] << 8 );   /* FALLTHROUGH */         \
-    case 8:  _hj_j += ( (unsigned)_hj_key[7] << 24 );  /* FALLTHROUGH */         \
-    case 7:  _hj_j += ( (unsigned)_hj_key[6] << 16 );  /* FALLTHROUGH */         \
-    case 6:  _hj_j += ( (unsigned)_hj_key[5] << 8 );   /* FALLTHROUGH */         \
-    case 5:  _hj_j += _hj_key[4];                      /* FALLTHROUGH */         \
-    case 4:  _hj_i += ( (unsigned)_hj_key[3] << 24 );  /* FALLTHROUGH */         \
-    case 3:  _hj_i += ( (unsigned)_hj_key[2] << 16 );  /* FALLTHROUGH */         \
-    case 2:  _hj_i += ( (unsigned)_hj_key[1] << 8 );   /* FALLTHROUGH */         \
-    case 1:  _hj_i += _hj_key[0];                      /* FALLTHROUGH */         \
+    case 11: hashv += ( (unsigned)_hj_key[10] << 24 );                           \
+    /* FALLTHROUGH */                                                            \
+    case 10: hashv += ( (unsigned)_hj_key[9] << 16 );                            \
+    /* FALLTHROUGH */                                                            \
+    case 9:  hashv += ( (unsigned)_hj_key[8] << 8 );                             \
+    /* FALLTHROUGH */                                                            \
+    case 8:  _hj_j += ( (unsigned)_hj_key[7] << 24 );                            \
+    /* FALLTHROUGH */                                                            \
+    case 7:  _hj_j += ( (unsigned)_hj_key[6] << 16 );                            \
+    /* FALLTHROUGH */                                                            \
+    case 6:  _hj_j += ( (unsigned)_hj_key[5] << 8 );                             \
+    /* FALLTHROUGH */                                                            \
+    case 5:  _hj_j += _hj_key[4];                                                \
+    /* FALLTHROUGH */                                                            \
+    case 4:  _hj_i += ( (unsigned)_hj_key[3] << 24 );                            \
+    /* FALLTHROUGH */                                                            \
+    case 3:  _hj_i += ( (unsigned)_hj_key[2] << 16 );                            \
+    /* FALLTHROUGH */                                                            \
+    case 2:  _hj_i += ( (unsigned)_hj_key[1] << 8 );                             \
+    /* FALLTHROUGH */                                                            \
+    case 1:  _hj_i += _hj_key[0];                                                \
+    /* FALLTHROUGH */                                                            \
     default: ;                                                                   \
   }                                                                              \
   HASH_JEN_MIX(_hj_i, _hj_j, hashv);                                             \


### PR DESCRIPTION
The /* FALLTHROUGH */ comment must be on a new line from case statement, otherwise the compiler doesn't detect it.

https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wimplicit-fallthrough