### PR TITLE
ci: add GitHub Actions CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,11 @@ on:
     branches: [ "master" ]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  build-gcc:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - run: make -C tests EXTRA_CFLAGS="-W -Wall -Wextra -Wswitch-default"
@@ -16,22 +19,13 @@ jobs:
     - run: make -C tests clean ; make -C tests cplusplus
     - run: make -C tests clean ; make -C tests cplusplus EXTRA_CFLAGS=-DNO_DECLTYPE
   build-clang:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     env:
       CC: clang
       CXX: clang++
-    steps:
-    - uses: actions/checkout@v3
-    - run: make -C tests EXTRA_CFLAGS="-W -Wall -Wextra -Wswitch-default"
-    - run: make -C tests clean ; make -C tests pedantic
-    - run: make -C tests clean ; make -C tests pedantic EXTRA_CFLAGS=-DNO_DECLTYPE
-    - run: make -C tests clean ; make -C tests cplusplus
-    - run: make -C tests clean ; make -C tests cplusplus EXTRA_CFLAGS=-DNO_DECLTYPE
-  build-mac:
-    runs-on: macos-latest
-    needs:
-      - build
-      - build-clang
     steps:
     - uses: actions/checkout@v3
     - run: make -C tests EXTRA_CFLAGS="-W -Wall -Wextra -Wswitch-default"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Build and Test
+
+on:
+  push: # any branch
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: make -C tests EXTRA_CFLAGS="-W -Wall -Wextra -Wswitch-default"
+    - run: make -C tests clean ; make -C tests pedantic
+    - run: make -C tests clean ; make -C tests pedantic EXTRA_CFLAGS=-DNO_DECLTYPE
+    - run: make -C tests clean ; make -C tests cplusplus
+    - run: make -C tests clean ; make -C tests cplusplus EXTRA_CFLAGS=-DNO_DECLTYPE
+  build-clang:
+    runs-on: ubuntu-latest
+    env:
+      CC: clang
+      CXX: clang++
+    steps:
+    - uses: actions/checkout@v3
+    - run: make -C tests EXTRA_CFLAGS="-W -Wall -Wextra -Wswitch-default"
+    - run: make -C tests clean ; make -C tests pedantic
+    - run: make -C tests clean ; make -C tests pedantic EXTRA_CFLAGS=-DNO_DECLTYPE
+    - run: make -C tests clean ; make -C tests cplusplus
+    - run: make -C tests clean ; make -C tests cplusplus EXTRA_CFLAGS=-DNO_DECLTYPE
+  build-mac:
+    runs-on: macos-latest
+    needs:
+      - build
+      - build-clang
+    steps:
+    - uses: actions/checkout@v3
+    - run: make -C tests EXTRA_CFLAGS="-W -Wall -Wextra -Wswitch-default"
+    - run: make -C tests clean ; make -C tests pedantic
+    - run: make -C tests clean ; make -C tests pedantic EXTRA_CFLAGS=-DNO_DECLTYPE
+    - run: make -C tests clean ; make -C tests cplusplus
+    - run: make -C tests clean ; make -C tests cplusplus EXTRA_CFLAGS=-DNO_DECLTYPE


### PR DESCRIPTION
Adds a basic GitHub Actions CI action that copies https://github.com/troydhanson/uthash/blob/master/.travis.yml

Fixes https://github.com/troydhanson/uthash/issues/243

This action will run on:
  - a `git push` to any branch on any fork.
  - a PR just to the `master` branch

I've purposely kept the `.travis.yml` file, since we can always just use both GitHub Actions and Travis for a while, before deleting Travis once the maintainers are comfortable with GitHub Actions CI.

Potential improvements:
  - We could use https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs to reduce some of the copy-and-paste, but I couldn't think of any easy way to put both Clang/GCC into a Matrix.
  - We could add a GitHub Action that automatically builds the documentation, and publishes it to GitHub pages.
  - We can also add a CI badge to the README.md file:
    [![Build and Test](https://github.com/troydhanson/uthash/actions/workflows/build.yml/badge.svg)](https://github.com/troydhanson/uthash/actions/workflows/build.yml)