### PR TITLE
ci: add GitHub Action to build docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,16 @@
+name: Docs
+
+on:
+  push: # any branch
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install AsciiDoc
+        run: sudo apt-get update && sudo apt-get install asciidoc -y
+      - name: Build documentation with AsciiDoc
+        run: make -C doc


### PR DESCRIPTION
Adds a basic GitHub Action that builds the documentation.

As discussed in https://github.com/troydhanson/uthash/pull/245#issuecomment-1215249856, I haven't added automatic publishing to GitHub Pages.

However, if you do want automatic publishing of docs to GitHub pages, GitHub has recently added the feature where you can automatically publish a website through GitHub Actions, see <https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta/>:

It's still in Beta, but all you'd have to add is the following:

```yaml
      # old contents ...
      - name: installs docs to /tmp/uthash-gh-pages
        run: make -C doc stage
      - name: Upload docs
        uses: actions/upload-pages-artifact@v1
        with:
          path: /tmp/uthash-gh-pages
  publish:
    name: publish docs (main-branch only)
    if: github.ref == 'refs/heads/main'
    needs: build-docs
    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
    permissions:
      pages: write      # to deploy to Pages
      id-token: write   # to verify the deployment originates from an appropriate source
    # Deploy to the github-pages environment
    environment:
      name: github-pages
      url: ${{ steps.deployment.outputs.page_url }}
    # Specify runner + deployment step
    runs-on: ubuntu-latest
    steps:
      - name: Deploy to GitHub Pages
        id: deployment
        uses: actions/deploy-pages@v1
```