### PR TITLE
Update uthash.h and utlist.h to compile with the elbrus C compiler.

### DIFF
--- a/src/uthash.h
+++ b/src/uthash.h
@@ -51,7 +51,7 @@ typedef unsigned char uint8_t;
 #else                   /* VS2008 or older (or VS2010 in C mode) */
 #define NO_DECLTYPE
 #endif
-#elif defined(__BORLANDC__) || defined(__ICCARM__) || defined(__LCC__) && !defined(__e2k__) || defined(__WATCOMC__)
+#elif defined(__BORLANDC__) || defined(__ICCARM__) || defined(__LCC__) && !defined(__MCST__) || defined(__WATCOMC__)
 #define NO_DECLTYPE
 #else                   /* GNU, Sun and other compilers */
 #define DECLTYPE(x) (__typeof(x))

--- a/src/uthash.h
+++ b/src/uthash.h
@@ -51,7 +51,7 @@ typedef unsigned char uint8_t;
 #else                   /* VS2008 or older (or VS2010 in C mode) */
 #define NO_DECLTYPE
 #endif
-#elif defined(__BORLANDC__) || defined(__ICCARM__) || defined(__LCC__) || defined(__WATCOMC__)
+#elif defined(__BORLANDC__) || defined(__ICCARM__) || defined(__LCC__) && !defined(__e2k__) || defined(__WATCOMC__)
 #define NO_DECLTYPE
 #else                   /* GNU, Sun and other compilers */
 #define DECLTYPE(x) (__typeof(x))

--- a/src/utlist.h
+++ b/src/utlist.h
@@ -70,7 +70,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #else                   /* VS2008 or older (or VS2010 in C mode) */
 #define NO_DECLTYPE
 #endif
-#elif defined(__BORLANDC__) || defined(__ICCARM__) || defined(__LCC__) && !defined(__e2k__) || defined(__WATCOMC__)
+#elif defined(__BORLANDC__) || defined(__ICCARM__) || defined(__LCC__) && !defined(__MCST__) || defined(__WATCOMC__)
 #define NO_DECLTYPE
 #else                   /* GNU, Sun and other compilers */
 #define LDECLTYPE(x) __typeof(x)

--- a/src/utlist.h
+++ b/src/utlist.h
@@ -70,7 +70,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #else                   /* VS2008 or older (or VS2010 in C mode) */
 #define NO_DECLTYPE
 #endif
-#elif defined(__BORLANDC__) || defined(__ICCARM__) || defined(__LCC__) || defined(__WATCOMC__)
+#elif defined(__BORLANDC__) || defined(__ICCARM__) || defined(__LCC__) && !defined(__e2k__) || defined(__WATCOMC__)
 #define NO_DECLTYPE
 #else                   /* GNU, Sun and other compilers */
 #define LDECLTYPE(x) __typeof(x)


### PR DESCRIPTION
This fixes uthash.h and utlist.h to compile as expected with LCC (eLbrus C Compiler).
Elbrus has the `__LCC__` macro which is named the same as LCC (Retargetable Compiler for ANSI C), however, Elbrus supports `__typeof()`, so this adds a check for `__e2k__` which is defined by it.