### PR TITLE
GitHub CI: Also test building the docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: build # This name shows up in badge.svg
 
 on:
   push: # any branch
@@ -33,3 +33,9 @@ jobs:
     - run: make -C tests clean ; make -C tests pedantic EXTRA_CFLAGS=-DNO_DECLTYPE
     - run: make -C tests clean ; make -C tests cplusplus
     - run: make -C tests clean ; make -C tests cplusplus EXTRA_CFLAGS=-DNO_DECLTYPE
+  build-asciidoc:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: sudo apt-get update && sudo apt-get install asciidoc -y
+    - run: make -C doc


### PR DESCRIPTION
Basically #246, but with fewer files.

@aloisklink, what's the advantage of having two separate .yml files here? IIUC, the (only) advantage is that it would let us have two different README badges, e.g. "build is green but docs are red" — but actually I'd never want to get into that state, so, I think this single-build.yml approach makes more sense; am I right?