### PR TITLE
Fixed MSVC warning about conditional expression being constant

### DIFF
--- a/src/uthash.h
+++ b/src/uthash.h
@@ -159,7 +159,7 @@ do {                                                                            
   if (head) {                                                                    \
     unsigned _hf_bkt;                                                            \
     HASH_TO_BKT(hashval, (head)->hh.tbl->num_buckets, _hf_bkt);                  \
-    if (HASH_BLOOM_TEST((head)->hh.tbl, hashval) != 0) {                         \
+    if (HASH_BLOOM_TEST((head)->hh.tbl, hashval)) {                         \
       HASH_FIND_IN_BKT((head)->hh.tbl, hh, (head)->hh.tbl->buckets[ _hf_bkt ], keyptr, keylen, hashval, out); \
     }                                                                            \
   }                                                                              \
@@ -202,7 +202,7 @@ do {                                                                            
   HASH_BLOOM_BITSET((tbl)->bloom_bv, ((hashv) & (uint32_t)((1UL << (tbl)->bloom_nbits) - 1U)))
 
 #define HASH_BLOOM_TEST(tbl,hashv)                                               \
-  HASH_BLOOM_BITTEST((tbl)->bloom_bv, ((hashv) & (uint32_t)((1UL << (tbl)->bloom_nbits) - 1U)))
+  (HASH_BLOOM_BITTEST((tbl)->bloom_bv, ((hashv) & (uint32_t)((1UL << (tbl)->bloom_nbits) - 1U))) != 0)
 
 #else
 #define HASH_BLOOM_MAKE(tbl,oomed)


### PR DESCRIPTION
This is because the condition expands out to `1 != 0` if `HASH_BLOOM` is not defined. Instead, I've modified the `HASH_BLOOM_TEST` macro to include the `!= 0` when the left hand side will not just be `1`, and leave the comparison as `1` otherwise - apparently MSVC thinks `if ( 1 )` is fine.