### PR TITLE
Eliminate HASH_DEFINE_OWN_STDINT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2005-2022, Troy D. Hanson  https://troydhanson.github.io/uthash/
+Copyright (c) 2005-2025, Troy D. Hanson  https://troydhanson.github.io/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/doc/license.html
+++ b/doc/license.html
@@ -21,7 +21,7 @@
   <div id="mid">
       <div id="main">
 <pre>
-Copyright (c) 2005-2022, Troy D. Hanson  https://troydhanson.github.io/uthash/
+Copyright (c) 2005-2025, Troy D. Hanson  https://troydhanson.github.io/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/utarray.h
+++ b/src/utarray.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2008-2022, Troy D. Hanson  https://troydhanson.github.io/uthash/
+Copyright (c) 2008-2025, Troy D. Hanson  https://troydhanson.github.io/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/uthash.h
+++ b/src/uthash.h
@@ -30,12 +30,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stddef.h>   /* ptrdiff_t */
 #include <stdlib.h>   /* exit */
 
-#if defined(HASH_DEFINE_OWN_STDINT) && HASH_DEFINE_OWN_STDINT
-/* This codepath is provided for backward compatibility, but I plan to remove it. */
-#warning "HASH_DEFINE_OWN_STDINT is deprecated; please use HASH_NO_STDINT instead"
-typedef unsigned int uint32_t;
-typedef unsigned char uint8_t;
-#elif defined(HASH_NO_STDINT) && HASH_NO_STDINT
+#if defined(HASH_NO_STDINT) && HASH_NO_STDINT
+/* The user doesn't have <stdint.h>, and must figure out their own way
+   to provide definitions for uint8_t and uint32_t. */
 #else
 #include <stdint.h>   /* uint8_t, uint32_t */
 #endif

--- a/src/uthash.h
+++ b/src/uthash.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2003-2022, Troy D. Hanson  https://troydhanson.github.io/uthash/
+Copyright (c) 2003-2025, Troy D. Hanson  https://troydhanson.github.io/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/utlist.h
+++ b/src/utlist.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2007-2022, Troy D. Hanson  https://troydhanson.github.io/uthash/
+Copyright (c) 2007-2025, Troy D. Hanson  https://troydhanson.github.io/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/utringbuffer.h
+++ b/src/utringbuffer.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015-2022, Troy D. Hanson  https://troydhanson.github.io/uthash/
+Copyright (c) 2015-2025, Troy D. Hanson  https://troydhanson.github.io/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/utstack.h
+++ b/src/utstack.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2018-2022, Troy D. Hanson  https://troydhanson.github.io/uthash/
+Copyright (c) 2018-2025, Troy D. Hanson  https://troydhanson.github.io/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/utstring.h
+++ b/src/utstring.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2008-2022, Troy D. Hanson  https://troydhanson.github.io/uthash/
+Copyright (c) 2008-2025, Troy D. Hanson  https://troydhanson.github.io/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/tests/hashscan.c
+++ b/tests/hashscan.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2005-2022, Troy D. Hanson  https://troydhanson.github.io/uthash/
+Copyright (c) 2005-2025, Troy D. Hanson  https://troydhanson.github.io/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
This macro was introduced in https://github.com/troydhanson/uthash/commit/15ad04278f19adefad34353143d944cb0c007fe2 for the benefit of people
who were relying on "uthash.h" to define its own `uint8_t` and
`uint32_t` typedefs, instead of either (1) getting them from the
Standard Library or (2) getting them from the user-programmer
somehow (e.g. `typedef char uint8_t` before including "uthash.h").
I see two projects using `HASH_NO_STDINT`, but zero projects
using `HASH_DEFINE_OWN_STDINT`, and somehow five years have passed;
it's time to kill off `HASH_DEFINE_OWN_STDINT`.