### PR TITLE
[test] Respect user's CFLAGS more than our own added ones; remove EXTRA_CFLAGS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
-    - run: make -C tests EXTRA_CFLAGS="-W -Wall -Wextra -Wswitch-default"
+    - run: make -C tests CFLAGS="-W -Wall -Wextra -Wswitch-default"
     - run: make -C tests clean ; make -C tests pedantic
-    - run: make -C tests clean ; make -C tests pedantic EXTRA_CFLAGS=-DNO_DECLTYPE
+    - run: make -C tests clean ; make -C tests pedantic CFLAGS=-DNO_DECLTYPE
     - run: make -C tests clean ; make -C tests cplusplus
-    - run: make -C tests clean ; make -C tests cplusplus EXTRA_CFLAGS=-DNO_DECLTYPE
+    - run: make -C tests clean ; make -C tests cplusplus CFLAGS=-DNO_DECLTYPE
   build-clang:
     strategy:
       matrix:
@@ -28,11 +28,11 @@ jobs:
       CXX: clang++
     steps:
     - uses: actions/checkout@v3
-    - run: make -C tests EXTRA_CFLAGS="-W -Wall -Wextra -Wswitch-default"
+    - run: make -C tests CFLAGS="-W -Wall -Wextra -Wswitch-default"
     - run: make -C tests clean ; make -C tests pedantic
-    - run: make -C tests clean ; make -C tests pedantic EXTRA_CFLAGS=-DNO_DECLTYPE
+    - run: make -C tests clean ; make -C tests pedantic CFLAGS=-DNO_DECLTYPE
     - run: make -C tests clean ; make -C tests cplusplus
-    - run: make -C tests clean ; make -C tests cplusplus EXTRA_CFLAGS=-DNO_DECLTYPE
+    - run: make -C tests clean ; make -C tests cplusplus CFLAGS=-DNO_DECLTYPE
   build-asciidoc:
     runs-on: ubuntu-latest
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ matrix:
     compiler: clang
   - os: osx
 script:
-- make -C tests EXTRA_CFLAGS="-W -Wall -Wextra -Wswitch-default"
+- make -C tests CFLAGS="-W -Wall -Wextra -Wswitch-default"
 - make -C tests clean ; make -C tests pedantic
-- make -C tests clean ; make -C tests pedantic EXTRA_CFLAGS=-DNO_DECLTYPE
+- make -C tests clean ; make -C tests pedantic CFLAGS=-DNO_DECLTYPE
 - make -C tests clean ; make -C tests cplusplus
-- make -C tests clean ; make -C tests cplusplus EXTRA_CFLAGS=-DNO_DECLTYPE
+- make -C tests clean ; make -C tests cplusplus CFLAGS=-DNO_DECLTYPE

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -14,22 +14,21 @@ PROGS = test1 test2 test3 test4 test5 test6 test7 test8 test9   \
         test82 test83 test84 test85 test86 test87 test88 test89 \
         test90 test91 test92 test93 test94 test95 test96 test97 \
         test98
-CFLAGS += -I$(HASHDIR)
-#CFLAGS += -DHASH_BLOOM=16
-#CFLAGS += -O2
-CFLAGS += -g
-#CFLAGS += -Wstrict-aliasing=2
-CFLAGS += -Wall
-#CFLAGS += -Wextra
-#CFLAGS += -std=c89
-CFLAGS += ${EXTRA_CFLAGS}
+TEST_CFLAGS = -I$(HASHDIR)
+TEST_CFLAGS += -g
+#TEST_CFLAGS += -DHASH_BLOOM=16
+#TEST_CFLAGS += -O2
+TEST_CFLAGS += -Wall
+#TEST_CFLAGS += -Wstrict-aliasing=2
+#TEST_CFLAGS += -Wextra
+#TEST_CFLAGS += -std=c89
 
 ifeq ($(HASH_DEBUG),1)
-CFLAGS += -DHASH_DEBUG=1
+TEST_CFLAGS += -DHASH_DEBUG=1
 endif
 
 ifeq ($(HASH_PEDANTIC),1)
-CFLAGS += -pedantic
+TEST_CFLAGS += -pedantic
 endif
 
 TEST_TARGET=run_tests
@@ -75,35 +74,35 @@ cplusplus:
 	CC="$(CXX) -x c++" $(MAKE) all
 
 thorough:
-	$(MAKE) clean && $(MAKE) all EXTRA_CFLAGS='-pedantic'
-	$(MAKE) clean && $(MAKE) all EXTRA_CFLAGS='-pedantic -DHASH_BLOOM=16'
-	$(MAKE) clean && $(MAKE) tests_only EXTRA_CFLAGS='-pedantic -DHASH_BLOOM=16 -DHASH_DEBUG -DNO_DECLTYPE'
-	$(MAKE) clean && CC="$(CXX) -x c++" $(MAKE) all EXTRA_CFLAGS='-pedantic'
-	$(MAKE) clean && CC="$(CXX) -x c++" $(MAKE) all EXTRA_CFLAGS='-pedantic -DHASH_BLOOM=16'
-	$(MAKE) clean && CC="$(CXX) -x c++" $(MAKE) tests_only EXTRA_CFLAGS='-pedantic -DHASH_BLOOM=16 -DHASH_DEBUG -DNO_DECLTYPE'
+	$(MAKE) clean && $(MAKE) all CFLAGS="${CFLAGS} -pedantic"
+	$(MAKE) clean && $(MAKE) all CFLAGS="${CFLAGS} -pedantic -DHASH_BLOOM=16"
+	$(MAKE) clean && $(MAKE) tests_only CFLAGS="${CFLAGS} -pedantic -DHASH_BLOOM=16 -DHASH_DEBUG -DNO_DECLTYPE"
+	$(MAKE) clean && CC="$(CXX) -x c++" $(MAKE) all CFLAGS="${CFLAGS} -pedantic"
+	$(MAKE) clean && CC="$(CXX) -x c++" $(MAKE) all CFLAGS="${CFLAGS} -pedantic -DHASH_BLOOM=16"
+	$(MAKE) clean && CC="$(CXX) -x c++" $(MAKE) tests_only CFLAGS="${CFLAGS} -pedantic -DHASH_BLOOM=16 -DHASH_DEBUG -DNO_DECLTYPE"
 
 example: example.c $(HASHDIR)/uthash.h
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $(@).c
+	$(CC) $(TEST_CFLAGS) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $(@).c
 
 $(PROGS) $(UTILS) : $(HASHDIR)/uthash.h
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $(@).c
+	$(CC) $(TEST_CFLAGS) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $(@).c
 	@$(MKGITIGN)
 
 hashscan : $(HASHDIR)/uthash.h
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $(@).c
+	$(CC) $(TEST_CFLAGS) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $(@).c
 	@$(MKGITIGN)
 
 sleep_test : $(HASHDIR)/uthash.h
-	$(CC) $(CPPFLAGS) $(CFLAGS) -DHASH_BLOOM=16 $(LDFLAGS) -o $@ $(@).c
+	$(CC) $(TEST_CFLAGS) $(CPPFLAGS) $(CFLAGS) -DHASH_BLOOM=16 $(LDFLAGS) -o $@ $(@).c
 	@$(MKGITIGN)
 
 keystat : $(HASHDIR)/uthash.h
-	$(CC) $(CPPFLAGS) $(CFLAGS) -DHASH_FUNCTION=HASH_BER $(LDFLAGS) -o keystat.BER keystat.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) -DHASH_FUNCTION=HASH_FNV $(LDFLAGS) -o keystat.FNV keystat.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) -DHASH_FUNCTION=HASH_JEN $(LDFLAGS) -o keystat.JEN keystat.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) -DHASH_FUNCTION=HASH_OAT $(LDFLAGS) -o keystat.OAT keystat.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) -DHASH_FUNCTION=HASH_SAX $(LDFLAGS) -o keystat.SAX keystat.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) -DHASH_FUNCTION=HASH_SFH $(LDFLAGS) -o keystat.SFH keystat.c
+	$(CC) $(TEST_CFLAGS) $(CPPFLAGS) $(CFLAGS) -DHASH_FUNCTION=HASH_BER $(LDFLAGS) -o keystat.BER keystat.c
+	$(CC) $(TEST_CFLAGS) $(CPPFLAGS) $(CFLAGS) -DHASH_FUNCTION=HASH_FNV $(LDFLAGS) -o keystat.FNV keystat.c
+	$(CC) $(TEST_CFLAGS) $(CPPFLAGS) $(CFLAGS) -DHASH_FUNCTION=HASH_JEN $(LDFLAGS) -o keystat.JEN keystat.c
+	$(CC) $(TEST_CFLAGS) $(CPPFLAGS) $(CFLAGS) -DHASH_FUNCTION=HASH_OAT $(LDFLAGS) -o keystat.OAT keystat.c
+	$(CC) $(TEST_CFLAGS) $(CPPFLAGS) $(CFLAGS) -DHASH_FUNCTION=HASH_SAX $(LDFLAGS) -o keystat.SAX keystat.c
+	$(CC) $(TEST_CFLAGS) $(CPPFLAGS) $(CFLAGS) -DHASH_FUNCTION=HASH_SFH $(LDFLAGS) -o keystat.SFH keystat.c
 
 run_tests: $(PROGS)
 	perl $(TESTS)

--- a/tests/README
+++ b/tests/README
@@ -110,8 +110,8 @@ example:   builds the 'example' program from the user guide
 
 Testing a specific hash function
 --------------------------------
-Set EXTRA_CFLAGS with this Makefile to use a specific hash function:
-   EXTRA_CFLAGS=-DHASH_FUNCTION=HASH_BER make
+Set CFLAGS with this Makefile to use a specific hash function:
+   CFLAGS=-DHASH_FUNCTION=HASH_BER make
 
 Other files
 ================================================================================

--- a/tests/all_funcs
+++ b/tests/all_funcs
@@ -5,9 +5,9 @@ function proceed {
   if [ "$response" != "y" ]; then exit -1; fi
 }
 
-make clean tests_only EXTRA_CFLAGS='-DHASH_FUNCTION=HASH_BER'; proceed
-make clean tests_only EXTRA_CFLAGS='-DHASH_FUNCTION=HASH_FNV'; proceed
-make clean tests_only EXTRA_CFLAGS='-DHASH_FUNCTION=HASH_JEN'; proceed
-make clean tests_only EXTRA_CFLAGS='-DHASH_FUNCTION=HASH_OAT'; proceed
-make clean tests_only EXTRA_CFLAGS='-DHASH_FUNCTION=HASH_SAX'; proceed
-make clean tests_only EXTRA_CFLAGS='-DHASH_FUNCTION=HASH_SFH'; proceed
+make clean tests_only CFLAGS='-DHASH_FUNCTION=HASH_BER'; proceed
+make clean tests_only CFLAGS='-DHASH_FUNCTION=HASH_FNV'; proceed
+make clean tests_only CFLAGS='-DHASH_FUNCTION=HASH_JEN'; proceed
+make clean tests_only CFLAGS='-DHASH_FUNCTION=HASH_OAT'; proceed
+make clean tests_only CFLAGS='-DHASH_FUNCTION=HASH_SAX'; proceed
+make clean tests_only CFLAGS='-DHASH_FUNCTION=HASH_SFH'; proceed


### PR DESCRIPTION
See also commit 747bb96, from ten years ago, which first made us respect the user's CFLAGS here at all. But we still appended our own flags (e.g. `-I../src -Wall`) to the end of the command line, so the user couldn't override any of ours with their own.

GNU's guidelines seem like a good way to go:
> https://www.gnu.org/prep/standards/html_node/Command-Variables.html

The EXTRA_CFLAGS variable was introduced to force options to the end of the command line. Now that the user's CFLAGS are properly at the end, we can replace our use of EXTRA_CFLAGS with just CFLAGS.

All of this affects only how the tests are compiled, not anything about the library itself.