### PR TITLE
Update uthash.h to permit preallocation

### DIFF
--- a/src/uthash.h
+++ b/src/uthash.h
@@ -126,8 +126,14 @@ do {                                                                            
 #endif
 
 /* initial number of buckets */
+#ifndef HASH_INITIAL_NUM_BUCKETS
 #define HASH_INITIAL_NUM_BUCKETS 32U     /* initial number of buckets        */
+#endif
+
+#ifndef HASH_INITIAL_NUM_BUCKETS_LOG2
 #define HASH_INITIAL_NUM_BUCKETS_LOG2 5U /* lg2 of initial number of buckets */
+#endif
+
 #define HASH_BKT_CAPACITY_THRESH 10U     /* expand when bucket count reaches */
 
 /* calculate the element whose hash handle address is hhp */


### PR DESCRIPTION
Placed HASH_INITIAL_NUM_BUCKETS and HASH_INITIAL_NUM_BUCKETS_LOG2 into a #ifndef block so as to permit these values to be optionally defined in other code before inclusion of uthash.h and thus permit preallocation of hashtable when a lot of keys are expected to be added.