### PR TITLE
Bump version to v2.4.0.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2005-2025, Troy D. Hanson  https://troydhanson.github.io/uthash/
+Copyright (c) 2005-2026, Troy D. Hanson  https://troydhanson.github.io/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/doc/ChangeLog.txt
+++ b/doc/ChangeLog.txt
@@ -5,6 +5,15 @@ Click to return to the link:index.html[uthash home page].
 
 NOTE: This ChangeLog may be incomplete and/or incorrect. See the git commit log.
 
+Version 2.4.0 (2026-06-25)
+--------------------------
+* add utarray_replace (thanks, xunicatt!)
+* add LL_REVERSE/DL_REVERSE/CDL_REVERSE (thanks, xunicatt!)
+* add CDL_CONCAT (thanks, xunicatt!)
+* remove `oom` (deprecated in v2.2.0) in favor of `utarray_oom`
+* remove HASH_DEFINE_OWN_STDINT (added in v2.2.0), on the theory nobody uses it
+* use __typeof on the MCST Elbrus C Compiler (thanks, utf-4096!)
+
 Version 2.3.0 (2021-02-25)
 --------------------------
 * remove HASH_FCN; the HASH_FUNCTION and HASH_KEYCMP macros now behave similarly

--- a/doc/license.html
+++ b/doc/license.html
@@ -21,7 +21,7 @@
   <div id="mid">
       <div id="main">
 <pre>
-Copyright (c) 2005-2025, Troy D. Hanson  https://troydhanson.github.io/uthash/
+Copyright (c) 2005-2026, Troy D. Hanson  https://troydhanson.github.io/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/doc/userguide.txt
+++ b/doc/userguide.txt
@@ -1,7 +1,8 @@
 uthash User Guide
 =================
-Troy D. Hanson, Arthur O'Dwyer
-v2.3.0, February 2021
+Troy D. Hanson <tdh@tkhanson.net>
+Arthur O'Dwyer <arthur.j.odwyer@gmail.com>
+v2.4.0, June 2026
 
 To download uthash, follow this link back to the
 https://github.com/troydhanson/uthash[GitHub project page].

--- a/doc/utarray.txt
+++ b/doc/utarray.txt
@@ -1,7 +1,8 @@
 utarray: dynamic array macros for C
 ===================================
 Troy D. Hanson <tdh@tkhanson.net>
-v2.3.0, February 2021
+Arthur O'Dwyer <arthur.j.odwyer@gmail.com>
+v2.4.0, June 2026
 
 Here's a link back to the https://github.com/troydhanson/uthash[GitHub project page].
 

--- a/doc/utlist.txt
+++ b/doc/utlist.txt
@@ -1,7 +1,8 @@
 utlist: linked list macros for C structures
 ===========================================
 Troy D. Hanson <tdh@tkhanson.net>
-v2.3.0, February 2021
+Arthur O'Dwyer <arthur.j.odwyer@gmail.com>
+v2.4.0, June 2026
 
 Here's a link back to the https://github.com/troydhanson/uthash[GitHub project page].
 

--- a/doc/utringbuffer.txt
+++ b/doc/utringbuffer.txt
@@ -1,7 +1,7 @@
 utringbuffer: dynamic ring-buffer macros for C
 ==============================================
 Arthur O'Dwyer <arthur.j.odwyer@gmail.com>
-v2.3.0, February 2021
+v2.4.0, June 2026
 
 Here's a link back to the https://github.com/troydhanson/uthash[GitHub project page].
 

--- a/doc/utstack.txt
+++ b/doc/utstack.txt
@@ -1,7 +1,7 @@
 utstack: intrusive stack macros for C
 =====================================
 Arthur O'Dwyer <arthur.j.odwyer@gmail.com>
-v2.3.0, February 2021
+v2.4.0, June 2026
 
 Here's a link back to the https://github.com/troydhanson/uthash[GitHub project page].
 

--- a/doc/utstring.txt
+++ b/doc/utstring.txt
@@ -1,7 +1,8 @@
 utstring: dynamic string macros for C
 =====================================
 Troy D. Hanson <tdh@tkhanson.net>
-v2.3.0, February 2021
+Arthur O'Dwyer <arthur.j.odwyer@gmail.com>
+v2.4.0, June 2026
 
 Here's a link back to the https://github.com/troydhanson/uthash[GitHub project page].
 

--- a/package.json
+++ b/package.json
@@ -24,5 +24,5 @@
     "src/utstring.h"
   ],
 
-  "version": "2.3.0"
+  "version": "2.4.0"
 }

--- a/src/utarray.h
+++ b/src/utarray.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2008-2025, Troy D. Hanson  https://troydhanson.github.io/uthash/
+Copyright (c) 2008-2026, Troy D. Hanson  https://troydhanson.github.io/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef UTARRAY_H
 #define UTARRAY_H
 
-#define UTARRAY_VERSION 2.3.0
+#define UTARRAY_VERSION 2.4.0
 
 #include <stddef.h>  /* size_t */
 #include <string.h>  /* memset, etc */

--- a/src/uthash.h
+++ b/src/uthash.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2003-2025, Troy D. Hanson  https://troydhanson.github.io/uthash/
+Copyright (c) 2003-2026, Troy D. Hanson  https://troydhanson.github.io/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,7 +24,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef UTHASH_H
 #define UTHASH_H
 
-#define UTHASH_VERSION 2.3.0
+#define UTHASH_VERSION 2.4.0
 
 #include <string.h>   /* memcmp, memset, strlen */
 #include <stddef.h>   /* ptrdiff_t */

--- a/src/utlist.h
+++ b/src/utlist.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2007-2025, Troy D. Hanson  https://troydhanson.github.io/uthash/
+Copyright (c) 2007-2026, Troy D. Hanson  https://troydhanson.github.io/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,7 +24,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef UTLIST_H
 #define UTLIST_H
 
-#define UTLIST_VERSION 2.3.0
+#define UTLIST_VERSION 2.4.0
 
 #include <assert.h>
 

--- a/src/utringbuffer.h
+++ b/src/utringbuffer.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015-2025, Troy D. Hanson  https://troydhanson.github.io/uthash/
+Copyright (c) 2015-2026, Troy D. Hanson  https://troydhanson.github.io/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef UTRINGBUFFER_H
 #define UTRINGBUFFER_H
 
-#define UTRINGBUFFER_VERSION 2.3.0
+#define UTRINGBUFFER_VERSION 2.4.0
 
 #include <stdlib.h>
 #include <string.h>

--- a/src/utstack.h
+++ b/src/utstack.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2018-2025, Troy D. Hanson  https://troydhanson.github.io/uthash/
+Copyright (c) 2018-2026, Troy D. Hanson  https://troydhanson.github.io/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,7 +24,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef UTSTACK_H
 #define UTSTACK_H
 
-#define UTSTACK_VERSION 2.3.0
+#define UTSTACK_VERSION 2.4.0
 
 /*
  * This file contains macros to manipulate a singly-linked list as a stack.

--- a/src/utstring.h
+++ b/src/utstring.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2008-2025, Troy D. Hanson  https://troydhanson.github.io/uthash/
+Copyright (c) 2008-2026, Troy D. Hanson  https://troydhanson.github.io/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef UTSTRING_H
 #define UTSTRING_H
 
-#define UTSTRING_VERSION 2.3.0
+#define UTSTRING_VERSION 2.4.0
 
 #include <stdlib.h>
 #include <string.h>

--- a/tests/hashscan.c
+++ b/tests/hashscan.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2005-2025, Troy D. Hanson  https://troydhanson.github.io/uthash/
+Copyright (c) 2005-2026, Troy D. Hanson  https://troydhanson.github.io/uthash/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Compare to the v2.3.0 bump, commit e493aa90a2833b4655927598f169c31cfcdf7861.
Attention: @xunicatt @utf-4096, both mentioned in the Changelog for contributing notable features to this release — thank you!

Addresses #281.