### PR TITLE
doc: Tell asciidoc to use \n, not \r\n, for newlines in HTML

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -5,7 +5,7 @@ all: $(HTML)
 # when each target of a multi-target rule has its own prereq
 # we use a static pattern rule.
 $(HTML): %.html: %.txt
-	asciidoc -a toc2 $<
+	asciidoc -a toc2 -a newline='\n' $<
 
 TMP=/tmp/uthash-gh-pages
 stage:


### PR DESCRIPTION
This works with the moribund Python asciidoc (which is what's shipped by Homebrew on Mac OS X at the moment); I don't know if it will continue to work with the Ruby asciidoctor, so I'm not sure it makes sense to commit. But I'm putting it in a branch so I'll remember how to do it next time I need to regenerate the docs.

See https://github.com/asciidoc-py/asciidoc-py/issues/278 and https://github.com/asciidoctor/asciidoctor/issues/4550